### PR TITLE
Prevent mastery level from resetting for SkillsForm

### DIFF
--- a/src/lib/components/SkillsForm.svelte
+++ b/src/lib/components/SkillsForm.svelte
@@ -14,7 +14,7 @@
 		onUpdated({ form }) {
 			if (form.valid) {
 				// Only reset the title, that way the user doesn't have to specify level of mastery every single time
-				form.data.title = '';
+				$formData.title = '';
 			}
 		}
 	});

--- a/src/lib/components/SkillsForm.svelte
+++ b/src/lib/components/SkillsForm.svelte
@@ -9,7 +9,14 @@
 	export let data: SuperValidated<Infer<SkillsSchema>>;
 
 	const form = superForm(data, {
-		validators: zodClient(skillsSchema)
+		validators: zodClient(skillsSchema),
+		resetForm: false,
+		onUpdated({ form }) {
+			if (form.valid) {
+				// Only reset the title, that way the user doesn't have to specify level of mastery every single time
+				form.data.title = '';
+			}
+		}
 	});
 
 	const { form: formData, enhance } = form;


### PR DESCRIPTION
This PR stops the mastery level from being reset when submitting a new skill in the tech stack. This way a user can specify multiple skills with the same level without any issues.

One thing to note is that deleting an entry somehow resets the form, but I think this belongs to another PR.