### PR TITLE
Make formatDate method use Date.toLocaleString()

### DIFF
--- a/src/lib/utils/formatDate.ts
+++ b/src/lib/utils/formatDate.ts
@@ -7,13 +7,6 @@ export const formatDate = (dateInput: Date | string): string => {
 		throw new Error('Invalid date');
 	}
 
-	// Extract the year, month, day, hours, and minutes
-	const year = date.getFullYear();
-	const month = String(date.getMonth() + 1).padStart(2, '0'); // Months are zero-based
-	const day = String(date.getDate()).padStart(2, '0');
-	const hours = String(date.getHours()).padStart(2, '0'); // Hours in 24-hour format
-	const minutes = String(date.getMinutes()).padStart(2, '0');
-
 	// Return formatted date and time
-	return `${year}-${month}-${day} ${hours}:${minutes}`;
+	return date.toLocaleString();
 };


### PR DESCRIPTION
Instead of hardcoding a formatting method, dates should be displayed according to the user's locale. Using `Date.toLocaleString()` fixes this issue. This way, users with the `en-US` locale see dates in the month day year order, while other users that use a locale such as `fr-FR` see dates in the day month year order.