### PR TITLE
Make head commit URL clickable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,6 @@ jobs:
           curl -H "Content-Type: application/json" \
           -X POST \
           -d '{
-            "content": "## New deployment for '${{ github.repository }}'\n\n**Branch**: `${{ github.ref }}`\n**Commit Message**: `${{ github.event.head_commit.message }}`\n**Committer**: `${{ github.event.head_commit.committer.name }}`\n**View Changes**: `${{ github.event.head_commit.url }}`"
+            "content": "## New deployment for '${{ github.repository }}'\n\n**Branch**: `${{ github.ref }}`\n**Commit Message**: `${{ github.event.head_commit.message }}`\n**Committer**: `${{ github.event.head_commit.committer.name }}`\n**View Changes**: <${{ github.event.head_commit.url }}>"
           }' \
           ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
Currently the "View Changes" link is not clickable (see image). This PR aims to fix this.
![image](https://github.com/user-attachments/assets/bfd7c807-0aef-4fb4-a6c7-ec88af7bfc3a)
