### PR TITLE
Use typescript types for DnD and PublicProfile

### DIFF
--- a/src/lib/components/MyProfile/UserLinks.svelte
+++ b/src/lib/components/MyProfile/UserLinks.svelte
@@ -12,6 +12,7 @@
 
 	export let links: Link[]; // Use the Link type for the links prop
 	let dragDisabled = false;
+
 	const handleDrop = async () => {
 		dragDisabled = true;
 		await fetch('/profile/links/order', {

--- a/src/lib/components/Shared/DnD.svelte
+++ b/src/lib/components/Shared/DnD.svelte
@@ -1,24 +1,31 @@
 <script lang="ts">
-    import { dndzone } from 'svelte-dnd-action';
-    import type { Options, DndEvent, Item } from 'svelte-dnd-action';
+	import { dndzone } from 'svelte-dnd-action';
+	import type { Options, DndEvent, Item } from 'svelte-dnd-action';
 
-    export let items: any[];
-    export let updateNewItems: (newItems: any[]) => void;
-    export let onDrop: ((e: CustomEvent<DndEvent<Item>>) => void) | undefined = undefined;
-    export let containerTag: string = 'div';
-    export let dndOptions: Omit<Options<Item>, 'items'|'type'> = {};
-    export let type: string = crypto.randomUUID(); // By default DnD will have different types, to prevent dragging between DnD zones.
+	type T = $$Generic<Item>;
+	export let items: T[];
+	export let updateNewItems: (newItems: T[]) => void;
+	export let onDrop: ((e: CustomEvent<DndEvent<Item>>) => void) | undefined = undefined;
+	export let containerTag: string = 'div';
+	export let dndOptions: Omit<Options<Item>, 'items' | 'type'> = {};
+	export let type: string = crypto.randomUUID(); // By default DnD will have different types, to prevent dragging between DnD zones.
 
-
-    const handleDndConsider = (e: CustomEvent<DndEvent<Item>>) => {
-        updateNewItems(e.detail.items)
-    }
-    const handleDndFinalize = (e: CustomEvent<DndEvent<Item>>) => {
-        updateNewItems(e.detail.items)
-        onDrop && onDrop(e);
-    }
+	const handleDndConsider = (e: CustomEvent<DndEvent<T>>) => {
+		updateNewItems(e.detail.items);
+	};
+	const handleDndFinalize = (e: CustomEvent<DndEvent<T>>) => {
+		updateNewItems(e.detail.items);
+		onDrop?.(e);
+	};
 </script>
 
-<svelte:element this="{containerTag}" use:dndzone="{{ ...dndOptions, items, type }}" on:consider="{handleDndConsider}" on:finalize="{handleDndFinalize}" {...$$restProps}>
-    <slot></slot>
+<svelte:element
+	this={containerTag}
+	use:dndzone={{ ...dndOptions, items, type }}
+	on:consider={handleDndConsider}
+	on:finalize={handleDndFinalize}
+	{...$$restProps}
+>
+	<slot></slot>
 </svelte:element>
+

--- a/src/lib/components/Shared/DnD.svelte
+++ b/src/lib/components/Shared/DnD.svelte
@@ -5,9 +5,9 @@
 	type T = $$Generic<Item>;
 	export let items: T[];
 	export let updateNewItems: (newItems: T[]) => void;
-	export let onDrop: ((e: CustomEvent<DndEvent<Item>>) => void) | undefined = undefined;
+	export let onDrop: ((e: CustomEvent<DndEvent<T>>) => void) | undefined = undefined;
 	export let containerTag: string = 'div';
-	export let dndOptions: Omit<Options<Item>, 'items' | 'type'> = {};
+	export let dndOptions: Omit<Options<T>, 'items' | 'type'> = {};
 	export let type: string = crypto.randomUUID(); // By default DnD will have different types, to prevent dragging between DnD zones.
 
 	const handleDndConsider = (e: CustomEvent<DndEvent<T>>) => {
@@ -28,4 +28,3 @@
 >
 	<slot></slot>
 </svelte:element>
-

--- a/src/lib/types/PublicProfile.ts
+++ b/src/lib/types/PublicProfile.ts
@@ -1,5 +1,5 @@
 export interface PublicProfile {
-	links: { title: string; url: string }[];
-	skills: { title: string; level: string }[];
+	links: Array<{ title: string; url: string }>;
+	skills: Array<{ title: string; level: string }>;
 	username: string;
 }


### PR DESCRIPTION
DnD now uses a generic type `T` that extends `Item` instead of just `Item`. This way eslint doesn't complain when nothing is wrong, and it also provides better errors when there is actually something wrong.
I have also replaced the shorthand array syntax in `PublicProfile` with the generic `Array` type since it's more readable to use generics for objects.