### PR TITLE
Display level mastery labels instead of values for SkillsForm

### DIFF
--- a/src/lib/components/MyProfile/SkillsForm.svelte
+++ b/src/lib/components/MyProfile/SkillsForm.svelte
@@ -2,16 +2,19 @@
 	import * as Form from '$lib/components/ui/form';
 	import { Input } from '$lib/components/ui/input';
 	import { skillsSchema, type SkillsSchema } from '$lib/schemas/skills';
-	import { Select } from 'bits-ui';
+	import { Select, type Selected } from 'bits-ui';
 	import { type SuperValidated, type Infer, superForm } from 'sveltekit-superforms';
 	import { zodClient } from 'sveltekit-superforms/adapters';
 	import type { Skill } from '@prisma/client';
+	import { masteryLevels } from '$lib/constants/masteryLevel';
+	import { getMasteryLevelFromLabel, getMasteryLevelFromLevel } from '$lib/utils/getMasteryLevel';
 
 	export let data: SuperValidated<Infer<SkillsSchema>>;
 	export let skillsLength: number;
 	export let skills: Skill[] = [];
 	let isLimitReached = false;
 	$: isLimitReached = skills.length >= 15;
+
 	const form = superForm(data, {
 		validators: zodClient(skillsSchema),
 		resetForm: false,
@@ -23,15 +26,28 @@
 		}
 	});
 
-	const { form: formData, enhance ,message} = form;
+	const { form: formData, enhance, message } = form;
 
 	$: $formData.order = skillsLength;
-	$: selectedLevel = $formData.level
-		? {
-				label: $formData.level,
-				value: $formData.level
+	$: selectedLevel = {
+		value: '',
+		label: ''
+	};
+
+	const onSelectedChange = (selected: Selected<string> | undefined) => {
+		if (selected) {
+			const level = getMasteryLevelFromLabel(selected.value);
+			if (level) {
+				$formData.level = level.value;
 			}
-		: undefined;
+		}
+	};
+
+	formData.subscribe((current) => {
+		if (!selectedLevel) selectedLevel = { label: '', value: '' };
+		selectedLevel.label = getMasteryLevelFromLevel(current.level)?.label ?? '';
+		selectedLevel.value = current.level;
+	});
 </script>
 
 <form
@@ -40,7 +56,7 @@
 	action="?/createSkill"
 	class="flex items-center justify-center space-x-4"
 >
-	<div class="flex flex-col">
+	<div class="flex items-stretch space-x-2">
 		<Form.Field {form} name="title">
 			<Form.Control let:attrs>
 				<Form.Label>Title</Form.Label>
@@ -48,47 +64,38 @@
 			</Form.Control>
 			<Form.FieldErrors />
 		</Form.Field>
-	</div>
 
-	<div class="flex flex-col">
 		<Form.Field {form} name="level">
 			<Form.Control let:attrs>
 				<Form.Label>Level of mastery</Form.Label>
-				<Select.Root
-					selected={selectedLevel}
-					onSelectedChange={(v) => {
-						v && ($formData.level = v.value);
-					}}
-				>
+				<Select.Root selected={selectedLevel} {onSelectedChange}>
 					<Select.Trigger {...attrs}>
 						<Select.Value placeholder="Select the level of your skill" />
 					</Select.Trigger>
 					<Select.Content>
-						<Select.Item value="1" label="Novice" />
-						<Select.Item value="2" label="Intermediate" />
-						<Select.Item value="3" label="Competent" />
-						<Select.Item value="4" label="Proficient" />
-						<Select.Item value="5" label="Expert" />
+						{#each masteryLevels as mastery}
+							<Select.Item value={mastery.label} label={mastery.label} />
+						{/each}
 					</Select.Content>
 				</Select.Root>
 				<input hidden bind:value={$formData.level} name={attrs.name} />
 			</Form.Control>
-
 			<Form.FieldErrors />
 		</Form.Field>
+
+		<Form.Field {form} name="order">
+			<Form.Control let:attrs>
+				<Input {...attrs} bind:value={$formData.order} type="hidden" />
+			</Form.Control>
+		</Form.Field>
+
+		<Form.Button disabled={isLimitReached}>Add</Form.Button>
 	</div>
-
-	<Form.Field {form} name="order">
-		<Form.Control let:attrs>
-			<Input {...attrs} bind:value={$formData.order} type="hidden" />
-		</Form.Control>
-	</Form.Field>
-
-	<Form.Button disabled = {isLimitReached}>Add</Form.Button>
 </form>
 
 {#if isLimitReached}
-  <p class="text-red-500 mt-2 text-center">You have reached the maximum limit of 15 skills.</p>
+	<p class="mt-2 text-center text-red-500">You have reached the maximum limit of 15 skills.</p>
 {:else if $message}
-  <p class="text-red-500 mt-2 text-center">{$message}</p>
+	<p class="mt-2 text-center text-red-500">{$message}</p>
 {/if}
+

--- a/src/lib/components/MyProfile/SkillsForm.svelte
+++ b/src/lib/components/MyProfile/SkillsForm.svelte
@@ -56,7 +56,7 @@
 	action="?/createSkill"
 	class="flex items-center justify-center space-x-4"
 >
-	<div class="flex items-stretch space-x-2">
+	<div class="flex items-center space-x-2">
 		<Form.Field {form} name="title">
 			<Form.Control let:attrs>
 				<Form.Label>Title</Form.Label>

--- a/src/lib/components/MyProfile/UserSkills.svelte
+++ b/src/lib/components/MyProfile/UserSkills.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { BriefcaseBusiness, Trash2, AlignJustify } from 'lucide-svelte';
-	import { masteryLevels } from '$lib/constants/masteryLevel';
+	import { getMasteryLevelFromLevel } from '$lib/utils/getMasteryLevel';
 	import { enhance } from '$app/forms';
 	import { Button } from '$lib/components/ui/button';
 	import { confirmDelete } from '$lib/utils/confirmDelete';
@@ -20,7 +20,7 @@
 			}
 		});
 		dragDisabled = false;
-	}
+	};
 </script>
 
 <DnD
@@ -30,14 +30,14 @@
 	class="grid gap-4"
 	onDrop={handleDrop}
 >
-	{#each skills as skill(skill.id)}
+	{#each skills as skill (skill.id)}
 		<div class="flex items-center gap-4">
 			<AlignJustify />
 			<BriefcaseBusiness />
 			<div class="grid gap-1">
 				<p class="text-sm font-medium leading-none">{skill.title}</p>
 				<p class="text-sm text-muted-foreground">
-					{masteryLevels.find((level) => level.value === String(skill.level))?.label}
+					{getMasteryLevelFromLevel(skill.level)?.label}
 				</p>
 			</div>
 			<div class="ml-auto font-medium">

--- a/src/lib/constants/masteryLevel.ts
+++ b/src/lib/constants/masteryLevel.ts
@@ -1,4 +1,6 @@
-export const masteryLevels = [
+import type { MasteryLevel } from '$lib/types/MasteryLevel';
+
+export const masteryLevels: MasteryLevel[] = [
 	{ value: '1', label: 'Novice' },
 	{ value: '2', label: 'Intermediate' },
 	{ value: '3', label: 'Competent' },

--- a/src/lib/types/MasteryLevel.ts
+++ b/src/lib/types/MasteryLevel.ts
@@ -1,0 +1,4 @@
+export interface MasteryLevel {
+  value: string;
+  label: string;
+}

--- a/src/lib/utils/getMasteryLevel.ts
+++ b/src/lib/utils/getMasteryLevel.ts
@@ -1,0 +1,10 @@
+import { masteryLevels } from '$lib/constants/masteryLevel';
+import type { MasteryLevel } from '$lib/types/MasteryLevel';
+
+export const getMasteryLevelFromLabel = (label: string): MasteryLevel | undefined => {
+  return masteryLevels.find((masteryLevel) => masteryLevel.label == label);
+};
+
+export const getMasteryLevelFromLevel = (level: string): MasteryLevel | undefined => {
+  return masteryLevels.find((masteryLevel) => masteryLevel.value == level);
+};


### PR DESCRIPTION
This PR fixes a display issue where the user skill form displays the wrong value. It also introduces a few utilities and types since the same functionalities are used in multiple files.

Before:
![image](https://github.com/user-attachments/assets/ff1bf212-7fce-47c9-b55f-8ef2eefb4384)
After:
![image](https://github.com/user-attachments/assets/3ef8311b-dc1b-4480-9f9c-65a9491b21bd)
