### PR TITLE
Display collaborating badge if there is only a username associated to the account

### DIFF
--- a/src/lib/components/PublicProfile/BasicInfo.svelte
+++ b/src/lib/components/PublicProfile/BasicInfo.svelte
@@ -10,6 +10,7 @@
 
 	export let githubData: GithubData | null;
 	export let userData: PublicProfile;
+	console.log(githubData);
 </script>
 
 <!-- User Avatar and Basic Info -->
@@ -24,24 +25,24 @@
 	</Avatar.Root>
 	<div class="flex flex-col space-y-4 text-center">
 		{#if githubData}
-			{#if githubData.name}
-				<div class="flex flex-col items-center justify-center gap-2">
+			<div class="flex flex-col items-center justify-center gap-2">
+				{#if githubData.name}
 					<p class="text-2xl font-bold">{githubData.name}</p>
-					<div class="badge">
-						{#if userData.isOpenToCollaborating}
-							<Badge variant="outline" class="border-green-700 text-green-700"
-								>Open to Collaborating</Badge
-							>
-						{:else}
-							<Badge variant="outline" class="border-red-700 text-red-700"
-								>Not Open to Collaborating</Badge
-							>
-						{/if}
-					</div>
+				{:else}
+					<p class="text-2xl font-bold">{userData.username}</p>
+				{/if}
+				<div class="badge">
+					{#if userData.isOpenToCollaborating}
+						<Badge variant="outline" class="border-green-700 text-green-700"
+							>Open to Collaborating</Badge
+						>
+					{:else}
+						<Badge variant="outline" class="border-red-700 text-red-700"
+							>Not Open to Collaborating</Badge
+						>
+					{/if}
 				</div>
-			{:else}
-				<p class="text-2xl font-bold">{userData.username}</p>
-			{/if}
+			</div>
 
 			{#if githubData.bio}
 				<p class="text-muted-foreground">{githubData.bio}</p>

--- a/src/lib/components/PublicProfile/BasicInfo.svelte
+++ b/src/lib/components/PublicProfile/BasicInfo.svelte
@@ -10,7 +10,6 @@
 
 	export let githubData: GithubData | null;
 	export let userData: PublicProfile;
-	console.log(githubData);
 </script>
 
 <!-- User Avatar and Basic Info -->
@@ -90,8 +89,9 @@
 				{/if}
 			</div>
 		{:else}
-			<div class="flex w-[300px] justify-center">
+			<div class="flex w-[300px] flex-col items-center space-y-2">
 				<Skeleton class="h-8 w-[75px]"></Skeleton>
+				<Skeleton class="h-6 w-[100px]"></Skeleton>
 			</div>
 			<Skeleton class="h-6 w-[300px]"></Skeleton>
 


### PR DESCRIPTION
Currently the badge is only displayed if the account has a name (and not a username).
Account with name: https://testing.route2.dev/s1lvax
Account with username https://testing.route2.dev/Discusser

This PR fixes this issue