### PR TITLE
Favor console.error for printing errors

### DIFF
--- a/src/lib/utils/deleteUser.ts
+++ b/src/lib/utils/deleteUser.ts
@@ -17,7 +17,7 @@ export const deleteUser = async (githubId: number, userId: number) => {
 			where: { githubId, id: userId }
 		});
 	} catch (error) {
-		console.log(error);
+		console.error(error);
 		throw Error('Failed to delete user');
 	}
 };

--- a/src/lib/utils/updateOpenToCollaborating.ts
+++ b/src/lib/utils/updateOpenToCollaborating.ts
@@ -21,7 +21,7 @@ export const updateOpenToCollaborating = async (githubId: number) => {
 			data: { openToCollaborating: newOpenToCollaboratingValue }
 		});
 	} catch (error) {
-		console.log(error);
+		console.error(error);
 		throw new Error('Failed to update openToCollaborating status');
 	}
 };

--- a/src/routes/profile/+page.server.ts
+++ b/src/routes/profile/+page.server.ts
@@ -133,7 +133,7 @@ export const actions: Actions = {
 				});
 			}
 		} catch (err) {
-			console.log(err);
+			console.error(err);
 			return fail(500, { message: 'Something went wrong.' });
 		}
 	},
@@ -192,7 +192,7 @@ export const actions: Actions = {
 				});
 			}
 		} catch (err) {
-			console.log(err);
+			console.error(err);
 			return fail(500, { message: 'Something went wrong.' });
 		}
 	},
@@ -211,7 +211,7 @@ export const actions: Actions = {
 				//make sure it's the correct user
 				deleteUser(user.githubId, Number(id));
 			} catch (error) {
-				console.log(error);
+				console.error(error);
 				throw Error('Failed to delete user');
 			}
 		}
@@ -225,7 +225,7 @@ export const actions: Actions = {
 				// update value
 				updateOpenToCollaborating(user.githubId);
 			} catch (error) {
-				console.log(error);
+				console.error(error);
 				throw Error('Failed to delete user');
 			}
 		}


### PR DESCRIPTION
According to NodeJS docs (https://nodejs.org/api/console.html#consoleerrordata-args), `console.error` prints to `stderr` instead of `stdout`. By default both `console.error` and `console.log` just print to the terminal, but using `console.error` allows for redirecting errors when needed.