### PR TITLE
Implement skeleton for avatars

### DIFF
--- a/src/lib/components/PublicProfile/BasicInfo.svelte
+++ b/src/lib/components/PublicProfile/BasicInfo.svelte
@@ -17,9 +17,9 @@
 	<Avatar.Root class="h-24 w-24 rounded-full">
 		{#if githubData}
 			<Avatar.Image src={githubData.avatarUrl} alt="User Avatar" />
-			<Avatar.Fallback>?</Avatar.Fallback>
+			<Avatar.Fallback><Skeleton class="h-full w-full rounded-full" /></Avatar.Fallback>
 		{:else}
-			<Skeleton class="h-full w-full rounded-full"></Skeleton>
+			<Skeleton class="h-full w-full rounded-full" />
 		{/if}
 	</Avatar.Root>
 	<div class="flex flex-col space-y-4 text-center">

--- a/src/lib/components/Shared/Navbar.svelte
+++ b/src/lib/components/Shared/Navbar.svelte
@@ -27,7 +27,7 @@
 					<a href="/profile">
 						<Avatar.Root>
 							<Avatar.Image src={$page.data.session.user.image} alt="@github.user" />
-							<Avatar.Fallback><Skeleton class="h-10 w-10 rounded-full" /></Avatar.Fallback>
+							<Avatar.Fallback><Skeleton class="h-full w-full rounded-full" /></Avatar.Fallback>
 						</Avatar.Root>
 					</a>
 				{/if}

--- a/src/lib/components/Shared/Navbar.svelte
+++ b/src/lib/components/Shared/Navbar.svelte
@@ -8,6 +8,7 @@
 
 	import * as Avatar from '$lib/components/ui/avatar';
 	import LightDarkMode from '$lib/components/Shared/LightDarkMode.svelte';
+	import { Skeleton } from '$lib/components/ui/skeleton';
 </script>
 
 <header class="sticky top-0 z-10 items-center border-b bg-background">
@@ -26,7 +27,7 @@
 					<a href="/profile">
 						<Avatar.Root>
 							<Avatar.Image src={$page.data.session.user.image} alt="@github.user" />
-							<Avatar.Fallback>X</Avatar.Fallback>
+							<Avatar.Fallback><Skeleton class="h-10 w-10 rounded-full" /></Avatar.Fallback>
 						</Avatar.Root>
 					</a>
 				{/if}


### PR DESCRIPTION
In the navbar, `$page.data.session.user.image` is never null, yet we still see the fallback "X" for some time before it loads. Replacing the fallback "X" with a skeleton fixes this issue.
Setting the fallback to a skeleton not only ensures that the skeleton will be displayed while the image is loading, it also guarantees that the skeleton will continue being displayed if the image could not load 