### PR TITLE
Move anchors around table rows inside of cells

### DIFF
--- a/src/lib/components/PublicProfile/Links.svelte
+++ b/src/lib/components/PublicProfile/Links.svelte
@@ -22,11 +22,13 @@
 				</Table.Header>
 				<Table.Body>
 					{#each userData.links as link}
-						<a href={link.url} target="_blank">
-							<Table.Row class="flex flex-row space-x-4 hover:cursor-pointer">
-								<Table.Cell class="font-medium">{link.title}</Table.Cell>
-							</Table.Row>
-						</a>
+						<Table.Row class="space-x-4 border-b-0 hover:cursor-pointer">
+							<Table.Cell class="p-0 font-medium">
+								<a class="block p-4" href={link.url} target="_blank">
+									<span>{link.title}</span>
+								</a>
+							</Table.Cell>
+						</Table.Row>
 					{/each}
 				</Table.Body>
 			</Table.Root>

--- a/src/lib/components/PublicProfile/UserInfo.svelte
+++ b/src/lib/components/PublicProfile/UserInfo.svelte
@@ -74,9 +74,9 @@
 					<Table.Body class="[&>*]:border-b-0">
 						<!-- GitHub Profile -->
 						<Table.Row>
-							<Table.Cell>
+							<Table.Cell class="p-0">
 								<a
-									class="flex items-center space-x-8"
+									class="flex items-center space-x-8 p-4"
 									href={githubData?.url ?? '#'}
 									target="_blank"
 								>
@@ -89,9 +89,9 @@
 						<!-- Blog Profile -->
 						{#if githubData?.blog}
 							<Table.Row>
-								<Table.Cell>
+								<Table.Cell class="p-0">
 									<a
-										class="flex items-center space-x-8"
+										class="flex items-center space-x-8 p-4"
 										href={githubData?.blog ?? '#'}
 										target="_blank"
 									>
@@ -105,9 +105,9 @@
 						<!-- Twitter Profile -->
 						{#if githubData?.twitter}
 							<Table.Row>
-								<Table.Cell>
+								<Table.Cell class="p-0">
 									<a
-										class="flex items-center space-x-8"
+										class="flex items-center space-x-8 p-4"
 										href={`https://x.com/${githubData?.twitter}`}
 										target="_blank"
 									>

--- a/src/lib/components/PublicProfile/UserInfo.svelte
+++ b/src/lib/components/PublicProfile/UserInfo.svelte
@@ -69,42 +69,53 @@
 					<Table.Header>
 						<Table.Row>
 							<Table.Head>Platform</Table.Head>
-							<Table.Head></Table.Head>
 						</Table.Row>
 					</Table.Header>
-					<Table.Body>
+					<Table.Body class="[&>*]:border-b-0">
 						<!-- GitHub Profile -->
-						<a href={githubData?.url ?? '#'} target="_blank">
-							<Table.Row>
-								<Table.Cell>
+						<Table.Row>
+							<Table.Cell>
+								<a
+									class="flex items-center space-x-8"
+									href={githubData?.url ?? '#'}
+									target="_blank"
+								>
 									<GitHub />
-								</Table.Cell>
-								<Table.Cell>GitHub Profile</Table.Cell>
-							</Table.Row>
-						</a>
+									<span>GitHub Profile</span>
+								</a>
+							</Table.Cell>
+						</Table.Row>
 
 						<!-- Blog Profile -->
 						{#if githubData?.blog}
-							<a href={githubData?.blog ?? '#'} target="_blank">
-								<Table.Row>
-									<Table.Cell>
+							<Table.Row>
+								<Table.Cell>
+									<a
+										class="flex items-center space-x-8"
+										href={githubData?.blog ?? '#'}
+										target="_blank"
+									>
 										<IdCard />
-									</Table.Cell>
-									<Table.Cell>Personal Website</Table.Cell>
-								</Table.Row>
-							</a>
+										<span>Personal Website</span>
+									</a>
+								</Table.Cell>
+							</Table.Row>
 						{/if}
 
 						<!-- Twitter Profile -->
 						{#if githubData?.twitter}
-							<a href={`https://x.com/${githubData?.twitter}`} target="_blank">
-								<Table.Row>
-									<Table.Cell>
+							<Table.Row>
+								<Table.Cell>
+									<a
+										class="flex items-center space-x-8"
+										href={`https://x.com/${githubData?.twitter}`}
+										target="_blank"
+									>
 										<Twitter />
-									</Table.Cell>
-									<Table.Cell>Twitter Profile</Table.Cell>
-								</Table.Row>
-							</a>
+										<span>Twitter Profile</span>
+									</a>
+								</Table.Cell>
+							</Table.Row>
 						{/if}
 						<!-- Socials will be here when we implement it -->
 					</Table.Body>


### PR DESCRIPTION
According to MDN web docs, a `<tr>` element (which is equivalent to `<Table.Row>` with shadcn), cannot be a child of an `<a>` element (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr#usage_notes). This, in turn, can cause some issues when displaying the table depending on the browser.
This PR fixes this issue by putting the anchor tag inside of the cell. Furthermore, I removed the padding on the cells, set the anchor tag's display to block so it would occupy the entire cell, and set the padding on the anchor tag, this way the entire cell is clickable as originally intended.