### PR TITLE
Make hobbies and socials scrollable

### DIFF
--- a/src/lib/components/PublicProfile/GithubStats.svelte
+++ b/src/lib/components/PublicProfile/GithubStats.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <!-- GitHub Stats Cards -->
-<div class="flex flex-col space-y-4">
+<div class="flex h-full flex-col justify-between space-y-4">
 	{#if githubData}
 		<StatsCard icon={Folder} title="Projects on Github" data={githubData.repoCount.toString()} />
 		<StatsCard

--- a/src/lib/components/PublicProfile/Hobbies.svelte
+++ b/src/lib/components/PublicProfile/Hobbies.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import * as Table from '$lib/components/ui/table';
-	import * as Card from '$lib/components/ui/card';
 	import type { PublicProfile } from '$lib/types/PublicProfile';
 
 	export let userData: PublicProfile;
@@ -12,7 +11,7 @@
 			<Table.Head>Hobbies</Table.Head>
 		</Table.Row>
 	</Table.Header>
-	<Table.Body>
+	<Table.Body class="block max-h-28 overflow-y-scroll [&>*]:border-b-0">
 		{#if userData.hobbies.length > 0}
 			{#each userData.hobbies as hobby}
 				<Table.Row class="flex flex-row space-x-4 hover:cursor-pointer">

--- a/src/lib/components/PublicProfile/ProfileHero.svelte
+++ b/src/lib/components/PublicProfile/ProfileHero.svelte
@@ -10,10 +10,10 @@
 
 <!-- User Avatar and Basic Info -->
 <div class="grid items-center gap-4 sm:grid-cols-1 md:grid-cols-[70%_30%]">
-	<div class="user-info">
+	<div class="user-info h-full">
 		<UserInfo {githubData} {userData} />
 	</div>
-	<div class="stats">
+	<div class="stats h-full">
 		<GithubStats {githubData} />
 	</div>
 </div>

--- a/src/lib/components/PublicProfile/PublicProfile.svelte
+++ b/src/lib/components/PublicProfile/PublicProfile.svelte
@@ -5,7 +5,6 @@
 	import Links from '$lib/components/PublicProfile/Links.svelte';
 	import TechStack from '$lib/components/PublicProfile/TechStack.svelte';
 	import ProfileFooter from '$lib/components/PublicProfile/ProfileFooter.svelte';
-	import Hobbies from '$lib/components/PublicProfile/Hobbies.svelte';
 	import ProfileHero from '$lib/components/PublicProfile/ProfileHero.svelte';
 	import { Separator } from '$lib/components//ui/separator';
 

--- a/src/lib/components/PublicProfile/Socials.svelte
+++ b/src/lib/components/PublicProfile/Socials.svelte
@@ -13,7 +13,7 @@
 			<Table.Head>Socials</Table.Head>
 		</Table.Row>
 	</Table.Header>
-	<Table.Body class="[&>*]:border-b-0">
+	<Table.Body class="block max-h-28 overflow-y-scroll [&>*]:border-b-0">
 		<!-- GitHub Profile -->
 		<Table.Row>
 			<Table.Cell class="p-0">

--- a/src/lib/components/PublicProfile/UserInfo.svelte
+++ b/src/lib/components/PublicProfile/UserInfo.svelte
@@ -15,7 +15,7 @@
 	export let userData: PublicProfile;
 </script>
 
-<Card.Root>
+<Card.Root class="flex h-full flex-col">
 	<!-- Card Header -->
 	<Card.Header>
 		<Card.Title>User Information</Card.Title>
@@ -23,8 +23,8 @@
 	</Card.Header>
 
 	<!-- Card Content -->
-	<Card.Content>
-		<div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+	<Card.Content class="flex-grow">
+		<div class="grid h-full grid-cols-1 gap-6 md:grid-cols-2">
 			<div class="introduction flex flex-col space-y-4">
 				<div class="flex flex-col items-center justify-center gap-2">
 					<Avatar.Root class="h-40 w-40 rounded-full">
@@ -65,9 +65,9 @@
 					</div>
 				</div>
 			</div>
-			<div class="information flex flex-col space-y-4">
+			<div class="information flex flex-col justify-between">
 				<div class="grid grid-cols-1 gap-2 md:grid-cols-2">
-					<div class="socials">
+					<div class="socials max-h-full">
 						<Socials {githubData} />
 					</div>
 					<div class="hobbies">


### PR DESCRIPTION
By doing this, the layout of the page won't change once the async data has loaded, since the socials table always has a fixed size. Furthermore, it's compact and fits nicely in the user info card.

![image](https://github.com/user-attachments/assets/aad27078-3fc3-4f0c-9a52-b395f2667d55)
