### PR TITLE
Import from github modal revision

### DIFF
--- a/src/lib/components/MyProfile/ImportFromGithub.svelte
+++ b/src/lib/components/MyProfile/ImportFromGithub.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import GitHub from 'lucide-svelte/icons/github';
+	import { IconBrandGithub } from '@tabler/icons-svelte';
 	import type { PageData } from '../../../routes/profile/$types';
 	import type { Repository } from '$lib/types/GithubData';
 	import ImportFromGithubModal from '$lib/components/MyProfile/ImportFromGithubModal.svelte';
@@ -26,13 +26,19 @@
 	};
 </script>
 
-<Button
-	disabled={isLimitReached}
-	class="mt-5 flex align-bottom"
-	on:click={() => fetchGithubRepos(data.userData.username)}
->
-	<GitHub /> Import from GitHub
-</Button>
+<div class="flex w-full space-x-4">
+	<div class="space-y-2">
+		<span class="invisible block">a</span>
+		<Button
+			disabled={isLimitReached}
+			class="flex space-x-2"
+			on:click={() => fetchGithubRepos(data.userData.username)}
+		>
+			<IconBrandGithub />
+			<span>Import from GitHub</span>
+		</Button>
+	</div>
+</div>
 
 {#if isModalVisible}
 	<ImportFromGithubModal {repos} {isModalVisible} {closeModal} linksLength={data.links.length} />

--- a/src/lib/components/MyProfile/ImportFromGithubModal.svelte
+++ b/src/lib/components/MyProfile/ImportFromGithubModal.svelte
@@ -38,6 +38,12 @@
 	$: sortedRepos = [...repos].sort((a, b) => b.stargazers_count - a.stargazers_count);
 
 	const importSelectedRepos = async () => {
+		// Return early to avoid wasting bandwidth
+		if (selectedRepos.size == 0) {
+			closeModal();
+			return;
+		}
+
 		const selectedData = Array.from(selectedRepos).map((repo) => ({
 			name: `GitHub - ${repo.name}`,
 			url: repo.html_url

--- a/src/lib/components/MyProfile/ImportFromGithubModal.svelte
+++ b/src/lib/components/MyProfile/ImportFromGithubModal.svelte
@@ -5,7 +5,7 @@
 	import * as Table from '$lib/components/ui/table';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Star } from 'lucide-svelte';
-	import { IconBrandGithub } from '@tabler/icons-svelte';
+	import { IconBrandGithub, IconChecks } from '@tabler/icons-svelte';
 
 	export let repos: Repository[] = [];
 	export let isModalVisible: boolean;
@@ -103,6 +103,7 @@
 												<Checkbox
 													checked={selectedRepos.has(repo)}
 													on:click={(e) => handleCheckboxClick(e, repo)}
+													disabled={isLimitReached && !selectedRepos.has(repo)}
 												/>
 											</div>
 										</Table.Cell>
@@ -124,9 +125,19 @@
 						</Table.Root>
 					</Card.Content>
 					<div class="flex flex-row items-center gap-2 p-4">
-						<Button type="button" on:click={importSelectedRepos} disabled={isLimitReached}
-							>Import</Button
+						<Button
+							type="button"
+							class="space-x-1"
+							on:click={importSelectedRepos}
+							disabled={isLimitReached}
 						>
+							{#if selectedRepos.size > 0}
+								<span>Import {selectedRepos.size}</span>
+								<IconChecks />
+							{:else}
+								<span>Import</span>
+							{/if}
+						</Button>
 						<Button type="button" variant="secondary" on:click={closeModal}>Cancel</Button>
 					</div>
 					{#if isLimitReached}

--- a/src/lib/components/MyProfile/ImportFromGithubModal.svelte
+++ b/src/lib/components/MyProfile/ImportFromGithubModal.svelte
@@ -99,13 +99,22 @@
 								{#each sortedRepos as repo}
 									<Table.Row>
 										<Table.Cell>
-											<Checkbox
-												checked={selectedRepos.has(repo)}
-												on:click={(e) => handleCheckboxClick(e, repo)}
-											/>
+											<div class="flex items-center">
+												<Checkbox
+													checked={selectedRepos.has(repo)}
+													on:click={(e) => handleCheckboxClick(e, repo)}
+												/>
+											</div>
 										</Table.Cell>
-										<Table.Cell class="font-medium">{repo.name}</Table.Cell>
-										<Table.Cell class="flex flex-row items-center gap-2">
+										<Table.Cell class="font-medium">
+											<a
+												href={repo.html_url}
+												target="_blank"
+												rel="noopener noreferrer"
+												class="text-blue-600 hover:underline">{repo.name}</a
+											>
+										</Table.Cell>
+										<Table.Cell class="flex items-center gap-2">
 											<Star class="text-sm" />
 											<span>{repo.stargazers_count}</span>
 										</Table.Cell>

--- a/src/lib/components/MyProfile/ImportFromGithubModal.svelte
+++ b/src/lib/components/MyProfile/ImportFromGithubModal.svelte
@@ -76,7 +76,7 @@
 
 		<div class="fixed inset-0 z-10 flex items-center justify-center overflow-y-auto">
 			<div
-				class="transform overflow-hidden rounded-lg bg-white shadow-xl transition-all sm:w-full sm:max-w-md"
+				class="h-3/4 transform overflow-scroll rounded-lg bg-white shadow-xl transition-all sm:w-full sm:max-w-md"
 			>
 				<Card.Root>
 					<Card.Header>
@@ -93,7 +93,7 @@
 									<Table.Head>Stars</Table.Head>
 								</Table.Row>
 							</Table.Header>
-							<Table.Body class="max-h-28 overflow-y-scroll">
+							<Table.Body class="max-h-28">
 								{#each sortedRepos as repo}
 									<Table.Row>
 										<Table.Cell>

--- a/src/lib/components/MyProfile/ImportFromGithubModal.svelte
+++ b/src/lib/components/MyProfile/ImportFromGithubModal.svelte
@@ -83,7 +83,7 @@
 
 		<div class="fixed inset-0 z-10 flex items-center justify-center overflow-y-auto">
 			<div
-				class="h-3/4 transform overflow-scroll rounded-lg bg-white shadow-xl transition-all sm:w-full sm:max-w-md"
+				class="max-h-[75%] transform overflow-scroll rounded-lg bg-white shadow-xl transition-all sm:w-full sm:max-w-md"
 			>
 				<Card.Root>
 					<Card.Header>

--- a/src/lib/components/MyProfile/ImportFromGithubModal.svelte
+++ b/src/lib/components/MyProfile/ImportFromGithubModal.svelte
@@ -4,7 +4,8 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Table from '$lib/components/ui/table';
 	import { Checkbox } from '$lib/components/ui/checkbox';
-	import { Star, Github } from 'lucide-svelte';
+	import { Star } from 'lucide-svelte';
+	import { IconBrandGithub } from '@tabler/icons-svelte';
 
 	export let repos: Repository[] = [];
 	export let isModalVisible: boolean;
@@ -81,7 +82,8 @@
 				<Card.Root>
 					<Card.Header>
 						<Card.Title class="flex flex-row items-center gap-2">
-							<Github /> Import From Github
+							<IconBrandGithub />
+							<span>Import From Github</span>
 						</Card.Title>
 					</Card.Header>
 					<Card.Content>
@@ -93,7 +95,7 @@
 									<Table.Head>Stars</Table.Head>
 								</Table.Row>
 							</Table.Header>
-							<Table.Body class="max-h-28">
+							<Table.Body class="overflow-scroll">
 								{#each sortedRepos as repo}
 									<Table.Row>
 										<Table.Cell>
@@ -105,7 +107,7 @@
 										<Table.Cell class="font-medium">{repo.name}</Table.Cell>
 										<Table.Cell class="flex flex-row items-center gap-2">
 											<Star class="text-sm" />
-											{repo.stargazers_count}
+											<span>{repo.stargazers_count}</span>
 										</Table.Cell>
 									</Table.Row>
 								{/each}

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -55,7 +55,7 @@
 					description="The links visible on your profile. You can drag links around to modify the order"
 					title="Links"
 				>
-					<div class="flex flex-row items-center gap-4">
+					<div class="flex flex-row items-stretch gap-4">
 						<LinkForm data={data.form} linksLength={data.links.length} links={data.links} />
 						<ImportFromGithub {data} />
 					</div>


### PR DESCRIPTION
This PR introduces a few changes:
- Import from github button is now aligned with the rest of the form fields in LinkForm
- The modal is scrollable and takes up at most 75% of the screen
- If the link limit is reached, unchecked checkboxes are disabled
- The import button now shows how many links will be imported
- No HTTP request is made if no repositories are imported
- The names of the repositories can now be clicked, and they lead to the repository on github