### PR TITLE
Added validation for socials URL

### DIFF
--- a/src/lib/components/MyProfile/SocialsForm.svelte
+++ b/src/lib/components/MyProfile/SocialsForm.svelte
@@ -6,7 +6,7 @@
 	import { zodClient } from 'sveltekit-superforms/adapters';
 
 	import * as Select from '$lib/components/ui/select';
-	import { socials } from '$lib/constants/socials';
+	import { socials, SocialsInputType } from '$lib/constants/socials';
 
 	export let data: SuperValidated<Infer<SocialsSchema>>;
 
@@ -23,6 +23,9 @@
 				value: $formData.social
 			}
 		: undefined;
+
+	$: selectedSocialInputType =
+		socials.find((s) => s.name === $formData.social)?.inputType ?? SocialsInputType.URL;
 </script>
 
 <form
@@ -58,9 +61,9 @@
 			</Form.Control>
 			<Form.FieldErrors />
 		</Form.Field>
-		<Form.Field {form} name="socialURL">
+		<Form.Field {form} name="socialURL" >
 			<Form.Control let:attrs>
-				<Form.Label>Social URL</Form.Label>
+				<Form.Label>{selectedSocialInputType}</Form.Label>
 				<Input {...attrs} bind:value={$formData.socialURL} />
 			</Form.Control>
 			<Form.FieldErrors />

--- a/src/lib/constants/socials.ts
+++ b/src/lib/constants/socials.ts
@@ -1,32 +1,47 @@
 //Social media
 // Import to add differences in how they're handled in the frontend
 
-//If the user should be redirected to a profile, make redirect true if not make redirect false and it will copy the contents to the clipboard
+// To be adjusted if we ever need more input types for socials
+export enum SocialsInputType {
+	URL = 'Social URL',
+	USERNAME = 'Social Username'
+}
 
+//If the user should be redirected to a profile, make redirect true if not make redirect false and it will copy the contents to the clipboard
 export const socials = [
 	{
 		name: 'Discord',
 		svg: '<svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="currentColor"  class="icon icon-tabler icons-tabler-filled icon-tabler-brand-discord"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14.983 3l.123 .006c2.014 .214 3.527 .672 4.966 1.673a1 1 0 0 1 .371 .488c1.876 5.315 2.373 9.987 1.451 12.28c-1.003 2.005 -2.606 3.553 -4.394 3.553c-.732 0 -1.693 -.968 -2.328 -2.045a21.512 21.512 0 0 0 2.103 -.493a1 1 0 1 0 -.55 -1.924c-3.32 .95 -6.13 .95 -9.45 0a1 1 0 0 0 -.55 1.924c.717 .204 1.416 .37 2.103 .494c-.635 1.075 -1.596 2.044 -2.328 2.044c-1.788 0 -3.391 -1.548 -4.428 -3.629c-.888 -2.217 -.39 -6.89 1.485 -12.204a1 1 0 0 1 .371 -.488c1.439 -1.001 2.952 -1.459 4.966 -1.673a1 1 0 0 1 .935 .435l.063 .107l.651 1.285l.137 -.016a12.97 12.97 0 0 1 2.643 0l.134 .016l.65 -1.284a1 1 0 0 1 .754 -.54l.122 -.009zm-5.983 7a2 2 0 0 0 -1.977 1.697l-.018 .154l-.005 .149l.005 .15a2 2 0 1 0 1.995 -2.15zm6 0a2 2 0 0 0 -1.977 1.697l-.018 .154l-.005 .149l.005 .15a2 2 0 1 0 1.995 -2.15z" /></svg>',
-		redirect: false
+		redirect: false,
+		inputType: SocialsInputType.USERNAME,
+		domains: ['discord.com']
 	},
 	{
 		name: 'LinkedIn',
 		svg: '<svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="icon icon-tabler icons-tabler-outline icon-tabler-brand-linkedin"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 4m0 2a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2z" /><path d="M8 11l0 5" /><path d="M8 8l0 .01" /><path d="M12 16l0 -5" /><path d="M16 16v-3a2 2 0 0 0 -4 0" /></svg>',
-		redirect: true
+		redirect: true,
+		inputType: SocialsInputType.URL,
+		domains: ['linkedin.com']
 	},
 	{
 		name: 'Telegram',
 		svg: '<svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="icon icon-tabler icons-tabler-outline icon-tabler-brand-telegram"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 10l-4 4l6 6l4 -16l-18 7l4 2l2 6l3 -4" /></svg>',
-		redirect: false
+		redirect: false,
+		inputType: SocialsInputType.USERNAME,
+		domains: ['t.me']
 	},
 	{
 		name: 'Spotify',
 		svg: '<svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="currentColor"  class="icon icon-tabler icons-tabler-filled icon-tabler-brand-spotify"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M17 3.34a10 10 0 1 1 -15 8.66l.005 -.324a10 10 0 0 1 14.995 -8.336m-2.168 11.605c-1.285 -1.927 -4.354 -2.132 -6.387 -.777a1 1 0 0 0 1.11 1.664c1.195 -.797 3.014 -.675 3.613 .223a1 1 0 1 0 1.664 -1.11m1.268 -3.245c-2.469 -1.852 -5.895 -2.187 -8.608 -.589a1 1 0 0 0 1.016 1.724c1.986 -1.171 4.544 -.92 6.392 .465a1 1 0 0 0 1.2 -1.6m1.43 -3.048c-3.677 -2.298 -7.766 -2.152 -10.977 -.546a1 1 0 0 0 .894 1.788c2.635 -1.317 5.997 -1.437 9.023 .454a1 1 0 1 0 1.06 -1.696" /></svg>',
-		redirect: true
+		redirect: true,
+		inputType: SocialsInputType.URL,
+		domains: ['spotify.com']
 	},
 	{
 		name: 'Gitlab',
 		svg: '<svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="icon icon-tabler icons-tabler-outline icon-tabler-brand-gitlab"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M21 14l-9 7l-9 -7l3 -11l3 7h6l3 -7z" /></svg>',
-		redirect: true
+		redirect: true,
+		inputType: SocialsInputType.URL,
+		domains: ['gitlab.com']
 	}
 ];

--- a/src/lib/schemas/socials.ts
+++ b/src/lib/schemas/socials.ts
@@ -1,8 +1,64 @@
+import { SocialsInputType } from '$lib/constants/socials';
+import { findSocial } from '$lib/utils/handleSocialClick';
 import { z } from 'zod';
 
-export const socialsSchema = z.object({
-	social: z.string().min(1).max(60),
-	socialURL: z.string().min(1).max(200)
-});
+export const socialsSchema = z
+	.object({
+		social: z.string().min(1).max(60),
+		socialURL: z.string().min(1).max(200)
+	})
+	.superRefine((obj, ctx) => {
+		const socialObject = findSocial(obj.social);
+		if (socialObject?.inputType !== SocialsInputType.URL) {
+			return;
+		}
+		if (!obj.socialURL) return;
+
+		const URLPattern = new RegExp(
+			'(https:\\/\\/www\\.|http:\\/\\/www\\.|https:\\/\\/|http:\\/\\/)?[a-zA-Z0-9]{2,}(\\.[a-zA-Z0-9]{2,})(\\.[a-zA-Z0-9]{2,})?'
+		);
+
+		const isUrlValid = URLPattern.test(obj.socialURL);
+
+		if (!isUrlValid) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.invalid_string,
+				message: 'Invalid URL',
+				path: ['socialURL'],
+				validation: 'url'
+			});
+			return;
+		}
+
+		// cleanup the URL by adding https:// if it's not already there
+		let url = obj.socialURL;
+
+		if (!(url.startsWith('http://') || url.startsWith('https://'))) {
+			url = 'https://' + url;
+		}
+
+		// extract the domain from the URL
+		const domain = new URL(url).hostname;
+
+		if (socialObject.domains.includes(domain)) {
+			return true;
+		}
+
+		ctx.addIssue({
+			code: z.ZodIssueCode.invalid_string,
+			message: 'URL provided is not a valid domain for the selected social',
+			validation: 'url',
+			path: ['socialURL']
+		});
+	})
+	.transform((data) => {
+		if (findSocial(data.social)?.inputType !== SocialsInputType.URL) return data;
+
+		// cleanup the URL by adding https:// if it's not already there
+		if (!(data.socialURL.startsWith('http://') || data.socialURL.startsWith('https://'))) {
+			data.socialURL = 'https://' + data.socialURL;
+		}
+		return data;
+	});
 
 export type SocialsSchema = typeof socialsSchema;

--- a/src/lib/utils/handleSocialClick.ts
+++ b/src/lib/utils/handleSocialClick.ts
@@ -2,7 +2,7 @@ import { socials as socialMediaList } from '$lib/constants/socials';
 import type { Social } from '@prisma/client';
 import { copyToClipboard } from './copyToClipboard';
 
-const findSocial = (socialName: string) => {
+export const findSocial = (socialName: string) => {
 	return socialMediaList.find((social) => social.name === socialName);
 };
 


### PR DESCRIPTION
I have added validation for social media URLs. 

In the process, I separated social providers that use usernames from those that require URLs. This ensures that the validation only occurs for URL-based providers. Additionally, I made sure to prepend "https://" to the URL, so that the **handleSocialClick** function works correctly when the redirect option is true.

Issues fixed: #103 and #104 

## Social URL Input:
### Old:
![image](https://github.com/user-attachments/assets/81345a30-9c22-4d75-a05f-d6b466ec29f4)

### New:
![image](https://github.com/user-attachments/assets/ae8eb613-722b-4051-bcb0-43584b2393e0)
![image](https://github.com/user-attachments/assets/5bca914f-e6d0-40d6-bf00-f77faae9012b)

## handleSocialClick function, if redirect is true:
### Old:
If user inputs example.com. When other people click the link in the profile, it will open a new tab, at "route2.dev/example.com".
### New:
If user inputs example.com, the function that handles the submit action will concatenate "https://" in front of the URL, if it doesn't have one, ensuring **handleSocialClick** works as expected, and go to "https://example.com" in a new tab.

