### PR TITLE
Add personal information to user profile

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,6 +61,13 @@ model Hobby {
   postedBy  User     @relation(fields: [userId], references: [githubId])
 }
 
+model PersonalInformation {
+  id       Int     @id @default(autoincrement())
+  userId   Int     @unique
+  email    String?
+  fullName String?
+}
+
 model Social {
   id        Int      @id @default(autoincrement())
   userId    Int

--- a/src/lib/components/MyProfile/PersonalInformation.svelte
+++ b/src/lib/components/MyProfile/PersonalInformation.svelte
@@ -1,36 +1,71 @@
 <script lang="ts">
 	import type { PersonalInformation } from '@prisma/client';
 	import * as Table from '$lib/components/ui/table';
+	import { Button } from '$lib/components/ui/button';
+	import { Trash2, Copy } from 'lucide-svelte';
+	import { confirmDelete } from '$lib/utils/confirmDelete';
+	import { enhance } from '$app/forms';
+	import { copyToClipboard } from '$lib/utils/copyToClipboard';
 
 	export let data: PersonalInformation;
+
+	$: isDataAvailable =
+		data != null &&
+		Object.entries(data)
+			.filter((entry) => !['userId', 'id'].includes(entry[0]))
+			.some((entry) => {
+				return entry[1] != '' && entry[1] != null;
+			});
+	$: rows = [
+		{ field: 'email', label: 'Email Address', value: () => data.email },
+		{ field: 'fullName', label: 'Full Name', value: () => data.fullName }
+	];
 </script>
 
-{#if data}
+{#if isDataAvailable}
 	<Table.Root>
 		<Table.Header>
 			<Table.Row></Table.Row>
 		</Table.Header>
 		<Table.Body>
-			{#if data.email}
-				<Table.Row>
-					<Table.Head>
-						<Table.Cell>Email Address</Table.Cell>
-					</Table.Head>
-					<Table.Cell>
-						{data.email}
-					</Table.Cell>
-				</Table.Row>
-			{/if}
-			{#if data.fullName}
-				<Table.Row>
-					<Table.Head>
-						<Table.Cell>Full Name</Table.Cell>
-					</Table.Head>
-					<Table.Cell>
-						{data.fullName}
-					</Table.Cell>
-				</Table.Row>
-			{/if}
+			{#each rows as row}
+				{#if row.value()}
+					<Table.Row>
+						<Table.Head>
+							<Table.Cell>{row.label}</Table.Cell>
+						</Table.Head>
+						<Table.Cell>
+							<div class="flex w-full items-center space-x-2">
+								<span>{row.value()}</span>
+								<Button
+									variant="ghost"
+									on:click={() => {
+										const val = row.value();
+										if (val) copyToClipboard(val);
+									}}
+								>
+									<Copy
+										class="h-4 w-4 transform transition-transform duration-300 hover:scale-110 hover:cursor-pointer"
+									/>
+								</Button>
+							</div>
+						</Table.Cell>
+						<Table.Cell>
+							<div class="float-right">
+								<form
+									action="?/resetPersonalInformation&field={row.field}"
+									method="POST"
+									use:enhance
+								>
+									<Button type="submit" variant="ghost" on:click={confirmDelete}>
+										<Trash2 />
+									</Button>
+								</form>
+							</div>
+						</Table.Cell>
+					</Table.Row>
+				{/if}
+			{/each}
 		</Table.Body>
 	</Table.Root>
 {:else}

--- a/src/lib/components/MyProfile/PersonalInformation.svelte
+++ b/src/lib/components/MyProfile/PersonalInformation.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import type { PersonalInformation } from '@prisma/client';
+	import * as Table from '$lib/components/ui/table';
+
+	export let data: PersonalInformation;
+</script>
+
+{#if data}
+	<Table.Root>
+		<Table.Header>
+			<Table.Row></Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#if data.email}
+				<Table.Row>
+					<Table.Head>
+						<Table.Cell>Email Address</Table.Cell>
+					</Table.Head>
+					<Table.Cell>
+						{data.email}
+					</Table.Cell>
+				</Table.Row>
+			{/if}
+			{#if data.fullName}
+				<Table.Row>
+					<Table.Head>
+						<Table.Cell>Full Name</Table.Cell>
+					</Table.Head>
+					<Table.Cell>
+						{data.fullName}
+					</Table.Cell>
+				</Table.Row>
+			{/if}
+		</Table.Body>
+	</Table.Root>
+{:else}
+	<p>No data yet</p>
+{/if}

--- a/src/lib/components/MyProfile/PersonalInformationForm.svelte
+++ b/src/lib/components/MyProfile/PersonalInformationForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import * as Form from '$lib/components/ui/form';
+	import { Input } from '$lib/components/ui/input';
+	import {
+		personalInformationSchema,
+		type PersonalInformationSchema
+	} from '$lib/schemas/personal-information';
+	import { type SuperValidated, type Infer, superForm } from 'sveltekit-superforms';
+	import { zodClient } from 'sveltekit-superforms/adapters';
+
+	export let data: SuperValidated<Infer<PersonalInformationSchema>>;
+
+	const form = superForm(data, {
+		validators: zodClient(personalInformationSchema),
+		resetForm: true,
+		onSubmit: ({ formData, cancel }) => {
+			// Don't make a request if there is nothing to update
+			if (formData.values().every((val) => val == null || val == '')) {
+				cancel();
+			}
+		}
+	});
+
+	const { form: formData, enhance } = form;
+</script>
+
+<form method="POST" use:enhance action="?/updatePersonalInformation" class="space-y-4">
+	<Form.Field {form} name="email">
+		<Form.Control let:attrs>
+			<Form.Label>Email</Form.Label>
+			<Input {...attrs} bind:value={$formData.email} />
+		</Form.Control>
+		<Form.FieldErrors />
+	</Form.Field>
+	<Form.Field {form} name="fullName">
+		<Form.Control let:attrs>
+			<Form.Label>Full Name</Form.Label>
+			<Input {...attrs} bind:value={$formData.fullName} />
+		</Form.Control>
+		<Form.FieldErrors />
+	</Form.Field>
+	<Form.Button>Update Information</Form.Button>
+</form>

--- a/src/lib/components/PublicProfile/ProfileHero.svelte
+++ b/src/lib/components/PublicProfile/ProfileHero.svelte
@@ -3,17 +3,15 @@
 	import type { PublicProfile } from '$lib/types/PublicProfile';
 	import GithubStats from '$lib/components/PublicProfile/GithubStats.svelte';
 	import UserInfo from '$lib/components/PublicProfile/UserInfo.svelte';
-	import type { Social } from '@prisma/client';
 
 	export let githubData: GithubData | null;
 	export let userData: PublicProfile;
-	export let socials: Social[];
 </script>
 
 <!-- User Avatar and Basic Info -->
 <div class="grid items-center gap-4 sm:grid-cols-1 md:grid-cols-[70%_30%]">
 	<div class="user-info h-full">
-		<UserInfo {githubData} {userData} {socials} />
+		<UserInfo {githubData} {userData} />
 	</div>
 	<div class="stats h-full">
 		<GithubStats {githubData} />

--- a/src/lib/components/PublicProfile/PublicProfile.svelte
+++ b/src/lib/components/PublicProfile/PublicProfile.svelte
@@ -19,7 +19,7 @@
 <!-- Main Profile Content -->
 <div class="flex min-h-screen w-full flex-col items-center">
 	<main class="flex w-full max-w-7xl flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
-		<ProfileHero {githubData} {userData} socials={userData.socials} />
+		<ProfileHero {githubData} {userData} />
 
 		<Separator class="my-4" />
 

--- a/src/lib/components/PublicProfile/UserInfo.svelte
+++ b/src/lib/components/PublicProfile/UserInfo.svelte
@@ -39,13 +39,27 @@
 
 					<div class="flex flex-col items-center justify-center space-y-4 text-center">
 						{#if githubData}
-							{#if userData.personalInformation?.fullName}
-								<p class="text-4xl font-bold">{userData.personalInformation.fullName}</p>
-							{:else if githubData?.name}
-								<p class="text-4xl font-bold">{githubData.name}</p>
-							{:else}
-								<p class="text-4xl font-bold">{userData.username}</p>
-							{/if}
+							<div class="flex flex-col items-center">
+								<div>
+									{#if userData.personalInformation?.fullName}
+										<p class="text-4xl font-bold">{userData.personalInformation.fullName}</p>
+									{:else if githubData?.name}
+										<p class="text-4xl font-bold">{githubData.name}</p>
+									{/if}
+									<p class="text-muted-foreground">{userData.username}</p>
+								</div>
+								{#if userData.personalInformation?.email}
+									<div class="flex items-center space-x-2">
+										<Mail class="h-4 w-4" />
+										<a
+											href="mailto:{userData.personalInformation.email}"
+											class="text-muted-foreground hover:underline"
+											>{userData.personalInformation.email}</a
+										>
+									</div>
+								{/if}
+							</div>
+
 							<!-- Collaborating Badge -->
 							{#if userData?.isOpenToCollaborating}
 								<Badge variant="outline" class="border-green-700 text-green-700"
@@ -65,17 +79,6 @@
 
 							{#if githubData?.company}
 								<p class="text-muted-foreground">Currently at {githubData?.company}</p>
-							{/if}
-
-							{#if userData.personalInformation?.email}
-								<div class="flex items-center space-x-2">
-									<Mail class="h-4 w-4" />
-									<a
-										href="mailto:{userData.personalInformation.email}"
-										class="text-muted-foreground hover:underline"
-										>{userData.personalInformation.email}</a
-									>
-								</div>
 							{/if}
 						{:else}
 							<Skeleton class="h-10 w-[200px]" />

--- a/src/lib/components/PublicProfile/UserInfo.svelte
+++ b/src/lib/components/PublicProfile/UserInfo.svelte
@@ -10,11 +10,10 @@
 	import Hobbies from '$lib/components/PublicProfile/Hobbies.svelte';
 	import Socials from '$lib/components/PublicProfile/Socials.svelte';
 	import MusicPlayer from '$lib/components/Shared/MusicPlayer.svelte';
-	import type { Social } from '@prisma/client';
+	import { Mail } from 'lucide-svelte';
 
 	export let githubData: GithubData | null;
 	export let userData: PublicProfile;
-	export let socials: Social[];
 </script>
 
 <Card.Root class="flex h-full flex-col">
@@ -40,7 +39,9 @@
 
 					<div class="flex flex-col items-center justify-center space-y-4 text-center">
 						{#if githubData}
-							{#if githubData?.name}
+							{#if userData.personalInformation?.fullName}
+								<p class="text-4xl font-bold">{userData.personalInformation.fullName}</p>
+							{:else if githubData?.name}
 								<p class="text-4xl font-bold">{githubData.name}</p>
 							{:else}
 								<p class="text-4xl font-bold">{userData.username}</p>
@@ -65,6 +66,17 @@
 							{#if githubData?.company}
 								<p class="text-muted-foreground">Currently at {githubData?.company}</p>
 							{/if}
+
+							{#if userData.personalInformation?.email}
+								<div class="flex items-center space-x-2">
+									<Mail class="h-4 w-4" />
+									<a
+										href="mailto:{userData.personalInformation.email}"
+										class="text-muted-foreground hover:underline"
+										>{userData.personalInformation.email}</a
+									>
+								</div>
+							{/if}
 						{:else}
 							<Skeleton class="h-10 w-[200px]" />
 							<Skeleton class="h-[22px] w-[150px] rounded-full" />
@@ -76,7 +88,7 @@
 			<div class="information flex flex-col justify-between">
 				<div class="grid grid-cols-1 gap-2 md:grid-cols-2">
 					<div class="socials max-h-full">
-						<Socials {githubData} {socials} />
+						<Socials {githubData} socials={userData.socials} />
 					</div>
 					<div class="hobbies">
 						<Hobbies {userData} />

--- a/src/lib/schemas/personal-information.ts
+++ b/src/lib/schemas/personal-information.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const personalInformationSchema = z.object({
+  email: z.string().email().nullable(),
+  fullName: z.string().nullable()
+});
+
+export type PersonalInformationSchema = typeof personalInformationSchema;

--- a/src/lib/schemas/personal-information.ts
+++ b/src/lib/schemas/personal-information.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
 export const personalInformationSchema = z.object({
-  email: z.string().email().nullable(),
-  fullName: z.string().nullable()
+  email: z.string().email().max(64).nullable(),
+  fullName: z.string().max(64).nullable()
 });
 
 export type PersonalInformationSchema = typeof personalInformationSchema;

--- a/src/lib/types/PublicProfile.ts
+++ b/src/lib/types/PublicProfile.ts
@@ -1,4 +1,4 @@
-import type { Social } from '@prisma/client';
+import type { PersonalInformation, Social } from '@prisma/client';
 
 export interface PublicProfile {
 	links: Array<{ title: string; url: string }>;
@@ -7,5 +7,6 @@ export interface PublicProfile {
 	isOpenToCollaborating: boolean | undefined;
 	hobbies: Array<{ hobby: string }>;
 	socials: Social[];
+	personalInformation: PersonalInformation | null;
 	chessComUsername: string | null;
 }

--- a/src/lib/utils/createRecentActivity.ts
+++ b/src/lib/utils/createRecentActivity.ts
@@ -14,7 +14,8 @@ export const createRecentActivity = async (
 		| 'SKILL_CREATED'
 		| 'SKILL_DELETED'
 		| 'CHESS_COM_CREATED'
-		| 'CHESS_COM_DELETED',
+		| 'CHESS_COM_DELETED'
+		| 'PERSONAL_INFORMATION_UPDATED',
 	activityDescription: string,
 	userId: number
 ): Promise<void> => {

--- a/src/routes/[username]/+page.server.ts
+++ b/src/routes/[username]/+page.server.ts
@@ -1,4 +1,5 @@
 import { prisma } from '$lib/server/prisma';
+import type { PublicProfile } from '$lib/types/PublicProfile';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params }) => {
@@ -48,14 +49,19 @@ export const load: PageServerLoad = async ({ params }) => {
 		where: { userId: user.githubId }
 	});
 
+	const personalInformation = await prisma.personalInformation.findFirst({
+		where: { userId: user.githubId }
+	});
+
 	const chessCom = await prisma.integrationChessCom.findUnique({
 		where: { userId: user.githubId }
 	});
 
-	const userData = {
+	const userData: PublicProfile = {
 		links,
 		skills,
 		socials,
+		personalInformation,
 		chessComUsername: chessCom ? chessCom.username : null,
 		username: username,
 		isOpenToCollaborating: isOpenToCollaborating?.openToCollaborating,

--- a/src/routes/profile/+layout.server.ts
+++ b/src/routes/profile/+layout.server.ts
@@ -9,6 +9,7 @@ import type { User } from '$lib/types/User';
 import { skillsSchema } from '$lib/schemas/skills';
 import { hobbiesSchema } from '$lib/schemas/hobbies';
 import { socialsSchema } from '$lib/schemas/socials';
+import { personalInformationSchema } from '$lib/schemas/personal-information';
 import type { LayoutServerLoad } from '../$types';
 import { chessComSchema } from '$lib/schemas/integration-chesscom';
 
@@ -64,6 +65,10 @@ export const load: LayoutServerLoad = async (event) => {
 		where: { userId: user.githubId }
 	});
 
+	const personalInformation = await prisma.personalInformation.findFirst({
+		where: { userId: user.githubId }
+	});
+
 	const socials = await prisma.social.findMany({
 		where: { userId: user.githubId }
 	});
@@ -84,6 +89,7 @@ export const load: LayoutServerLoad = async (event) => {
 	const skillsForm = await superValidate(zod(skillsSchema));
 	const hobbiesForm = await superValidate(zod(hobbiesSchema));
 	const socialsForm = await superValidate(zod(socialsSchema));
+	const personalInformationForm = await superValidate(zod(personalInformationSchema));
 	const chessComForm = await superValidate(zod(chessComSchema));
 
 	// Return data to the frontend
@@ -93,13 +99,15 @@ export const load: LayoutServerLoad = async (event) => {
 		links,
 		skills,
 		hobbies,
+		personalInformation,
 		socials,
 		spotifyToken,
 		chessComUsername,
 		form: linksForm,
-		skillsForm: skillsForm,
-		hobbiesForm: hobbiesForm,
-		socialsForm: socialsForm,
-		chessComForm: chessComForm
+		skillsForm,
+		hobbiesForm,
+		socialsForm,
+		personalInformationForm,
+		chessComForm
 	};
 };

--- a/src/routes/profile/personal/+page.server.ts
+++ b/src/routes/profile/personal/+page.server.ts
@@ -186,5 +186,43 @@ export const actions: Actions = {
 		return {
 			form
 		};
+	},
+	resetPersonalInformation: async ({ url }) => {
+		const field = url.searchParams.get('field');
+		const isValidField =
+			field != null &&
+			Object.keys(prisma.personalInformation.fields).includes(field) &&
+			field != 'id' &&
+			field != 'userId';
+
+		if (!isValidField) {
+			return fail(400, { message: 'Invalid request' });
+		}
+
+		try {
+			if (user) {
+				const update: Record<string, string> = {};
+				update[field] = '';
+
+				await prisma.personalInformation.upsert({
+					where: {
+						userId: user.githubId
+					},
+					update,
+					create: {
+						userId: user.githubId
+					}
+				});
+
+				createRecentActivity(
+					'PERSONAL_INFORMATION_UPDATED',
+					`Updated personal information`,
+					user.githubId
+				);
+			}
+		} catch (error) {
+			console.error(error);
+			throw Error('Failed to update personal information');
+		}
 	}
 };

--- a/src/routes/profile/personal/+page.svelte
+++ b/src/routes/profile/personal/+page.svelte
@@ -6,6 +6,8 @@
 	import UserSocials from '$lib/components/MyProfile/UserSocials.svelte';
 	import HobbyForm from '$lib/components/MyProfile/HobbyForm.svelte';
 	import UserHobbies from '$lib/components/MyProfile/UserHobbies.svelte';
+	import PersonalInformationForm from '$lib/components/MyProfile/PersonalInformationForm.svelte';
+	import PersonalInformation from '$lib/components/MyProfile/PersonalInformation.svelte';
 
 	export let data: PageData;
 </script>
@@ -39,6 +41,19 @@
 			</FormCardHeader>
 			<Card.Content class="grid gap-8">
 				<UserHobbies hobbies={data.hobbies} />
+			</Card.Content>
+		</Card.Root>
+	</div>
+	<div>
+		<Card.Root>
+			<FormCardHeader
+				title="Personal Information"
+				description="You can add information about yourself here"
+			>
+				<PersonalInformationForm data={data.personalInformationForm} />
+			</FormCardHeader>
+			<Card.Content class="grid gap-8">
+				<PersonalInformation data={data.personalInformation} />
 			</Card.Content>
 		</Card.Root>
 	</div>


### PR DESCRIPTION
This PR aims to implement #91 and provide some extensibility for future uses.
In /profile/personal, a new widget is available:
![image](https://github.com/user-attachments/assets/40a57ddf-8289-4f24-94c3-f521d9ccb7d5)
This data is displayed on the UserInfo component:
![image](https://github.com/user-attachments/assets/44a0ffdf-eb45-4b62-b9cd-ed68f65d0bc6)
