### PR TITLE
Fix URL validation in SocialsForm

### DIFF
--- a/src/lib/schemas/socials.ts
+++ b/src/lib/schemas/socials.ts
@@ -1,64 +1,8 @@
-import { SocialsInputType } from '$lib/constants/socials';
-import { findSocial } from '$lib/utils/handleSocialClick';
 import { z } from 'zod';
 
-export const socialsSchema = z
-	.object({
-		social: z.string().min(1).max(60),
-		socialURL: z.string().min(1).max(200)
-	})
-	.superRefine((obj, ctx) => {
-		const socialObject = findSocial(obj.social);
-		if (socialObject?.inputType !== SocialsInputType.URL) {
-			return;
-		}
-		if (!obj.socialURL) return;
-
-		const URLPattern = new RegExp(
-			'(https:\\/\\/www\\.|http:\\/\\/www\\.|https:\\/\\/|http:\\/\\/)?[a-zA-Z0-9]{2,}(\\.[a-zA-Z0-9]{2,})(\\.[a-zA-Z0-9]{2,})?'
-		);
-
-		const isUrlValid = URLPattern.test(obj.socialURL);
-
-		if (!isUrlValid) {
-			ctx.addIssue({
-				code: z.ZodIssueCode.invalid_string,
-				message: 'Invalid URL',
-				path: ['socialURL'],
-				validation: 'url'
-			});
-			return;
-		}
-
-		// cleanup the URL by adding https:// if it's not already there
-		let url = obj.socialURL;
-
-		if (!(url.startsWith('http://') || url.startsWith('https://'))) {
-			url = 'https://' + url;
-		}
-
-		// extract the domain from the URL
-		const domain = new URL(url).hostname;
-
-		if (socialObject.domains.includes(domain)) {
-			return true;
-		}
-
-		ctx.addIssue({
-			code: z.ZodIssueCode.invalid_string,
-			message: 'URL provided is not a valid domain for the selected social',
-			validation: 'url',
-			path: ['socialURL']
-		});
-	})
-	.transform((data) => {
-		if (findSocial(data.social)?.inputType !== SocialsInputType.URL) return data;
-
-		// cleanup the URL by adding https:// if it's not already there
-		if (!(data.socialURL.startsWith('http://') || data.socialURL.startsWith('https://'))) {
-			data.socialURL = 'https://' + data.socialURL;
-		}
-		return data;
-	});
+export const socialsSchema = z.object({
+	social: z.string().min(1).max(60),
+	socialURL: z.string().min(1).max(200).url()
+});
 
 export type SocialsSchema = typeof socialsSchema;


### PR DESCRIPTION
Previously, the URL in socialsSchema was validated using a regex pattern. This pattern wasn't exhaustive, as it didn't take into account `-` or `_` for example. I have replaced this with zod's `url()` method, which uses the `URL` object under the hood (see https://github.com/colinhacks/zod/blob/1f4f0dacf313a2dba45563d78171e6f016096925/src/types.ts#L820). This implementation is much more reliable and less error prone.

Furthermore, an issue arises when checking the domain names for URLs. For example, LinkedIn has `linkedin.com` as its only domain at the moment, which, with the current implementation, rejects `www.linkedin.com`, but that is trivial to solve. The main issue is that most websites have many domain names that lead to the same page. For example, a LinkedIn link can have `www.linkedin.fr` or `fr.linkedin.com` as its hostname. It's therefore almost impossible to check if a URL is valid for a specific website, since there are too many hostnames to keep track of.
For now, I have simply removed the hostname validation, but I will keep this PR as a draft until we figure out a better solution.