### PR TITLE
Revision for new dashboard

### DIFF
--- a/src/lib/components/Index/CTA.svelte
+++ b/src/lib/components/Index/CTA.svelte
@@ -3,7 +3,7 @@
 	import { UserPen } from 'lucide-svelte';
 	import { signIn } from '@auth/sveltekit/client';
 	import { page } from '$app/stores';
-	import { IconBrandGithub } from '@tabler/icons-svelte';
+	import { IconBrandGithub, IconBrandDiscordFilled } from '@tabler/icons-svelte';
 </script>
 
 <div>
@@ -18,48 +18,25 @@
 			</p>
 			<div class="mt-10 flex items-center justify-center gap-x-6">
 				{#if $page.data.session}
-					<Button href="/profile" class="flex items-center space-x-2"
-						><UserPen /> <span>My Profile</span></Button
-					>
-					<Button
-						href="https://discord.gg/9XuRcaZR"
-						target="_blank"
-						class="flex items-center space-x-2"
-						variant="secondary"
-						><svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="24"
-							height="24"
-							viewBox="0 0 24 24"
-							fill="currentColor"
-							class="icon icon-tabler icons-tabler-filled icon-tabler-brand-discord"
-							><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path
-								d="M14.983 3l.123 .006c2.014 .214 3.527 .672 4.966 1.673a1 1 0 0 1 .371 .488c1.876 5.315 2.373 9.987 1.451 12.28c-1.003 2.005 -2.606 3.553 -4.394 3.553c-.732 0 -1.693 -.968 -2.328 -2.045a21.512 21.512 0 0 0 2.103 -.493a1 1 0 1 0 -.55 -1.924c-3.32 .95 -6.13 .95 -9.45 0a1 1 0 0 0 -.55 1.924c.717 .204 1.416 .37 2.103 .494c-.635 1.075 -1.596 2.044 -2.328 2.044c-1.788 0 -3.391 -1.548 -4.428 -3.629c-.888 -2.217 -.39 -6.89 1.485 -12.204a1 1 0 0 1 .371 -.488c1.439 -1.001 2.952 -1.459 4.966 -1.673a1 1 0 0 1 .935 .435l.063 .107l.651 1.285l.137 -.016a12.97 12.97 0 0 1 2.643 0l.134 .016l.65 -1.284a1 1 0 0 1 .754 -.54l.122 -.009zm-5.983 7a2 2 0 0 0 -1.977 1.697l-.018 .154l-.005 .149l.005 .15a2 2 0 1 0 1.995 -2.15zm6 0a2 2 0 0 0 -1.977 1.697l-.018 .154l-.005 .149l.005 .15a2 2 0 1 0 1.995 -2.15z"
-							/></svg
-						> <span>Join the Community</span></Button
-					>
+					<Button href="/profile" class="flex items-center space-x-2">
+						<UserPen />
+						<span>My Profile</span>
+					</Button>
 				{:else}
-					<Button on:click={() => signIn('github')} class="flex items-center space-x-2"
-						><IconBrandGithub /> <span>Sign in with Github</span></Button
-					>
-					<Button
-						href="https://discord.gg/9XuRcaZR"
-						target="_blank"
-						class="flex items-center space-x-2"
-						variant="secondary"
-						><svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="24"
-							height="24"
-							viewBox="0 0 24 24"
-							fill="currentColor"
-							class="icon icon-tabler icons-tabler-filled icon-tabler-brand-discord"
-							><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path
-								d="M14.983 3l.123 .006c2.014 .214 3.527 .672 4.966 1.673a1 1 0 0 1 .371 .488c1.876 5.315 2.373 9.987 1.451 12.28c-1.003 2.005 -2.606 3.553 -4.394 3.553c-.732 0 -1.693 -.968 -2.328 -2.045a21.512 21.512 0 0 0 2.103 -.493a1 1 0 1 0 -.55 -1.924c-3.32 .95 -6.13 .95 -9.45 0a1 1 0 0 0 -.55 1.924c.717 .204 1.416 .37 2.103 .494c-.635 1.075 -1.596 2.044 -2.328 2.044c-1.788 0 -3.391 -1.548 -4.428 -3.629c-.888 -2.217 -.39 -6.89 1.485 -12.204a1 1 0 0 1 .371 -.488c1.439 -1.001 2.952 -1.459 4.966 -1.673a1 1 0 0 1 .935 .435l.063 .107l.651 1.285l.137 -.016a12.97 12.97 0 0 1 2.643 0l.134 .016l.65 -1.284a1 1 0 0 1 .754 -.54l.122 -.009zm-5.983 7a2 2 0 0 0 -1.977 1.697l-.018 .154l-.005 .149l.005 .15a2 2 0 1 0 1.995 -2.15zm6 0a2 2 0 0 0 -1.977 1.697l-.018 .154l-.005 .149l.005 .15a2 2 0 1 0 1.995 -2.15z"
-							/></svg
-						> <span>Join the Community</span></Button
-					>
+					<Button on:click={() => signIn('github')} class="flex items-center space-x-2">
+						<IconBrandGithub />
+						<span>Sign in with Github</span>
+					</Button>
 				{/if}
+				<Button
+					href="https://discord.gg/9XuRcaZR"
+					target="_blank"
+					class="flex items-center space-x-2"
+					variant="secondary"
+				>
+					<IconBrandDiscordFilled />
+					<span>Join the Community</span>
+				</Button>
 			</div>
 		</div>
 	</div>

--- a/src/lib/components/Index/Footer.svelte
+++ b/src/lib/components/Index/Footer.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { socials } from '$lib/constants/socials';
+	import { findSocialIcon } from '$lib/utils/findSocialIcon';
 </script>
 
 <footer class="border-t">
@@ -8,7 +9,7 @@
 			{#each socials as social}
 				<a href={social.link} class="text-gray-400 hover:text-gray-500">
 					<span class="sr-only">{social.name}</span>
-					<svelte:component this={social.icon} />
+					<svelte:component this={findSocialIcon(social.name)} />
 				</a>
 			{/each}
 		</div>

--- a/src/lib/components/Index/Hero.svelte
+++ b/src/lib/components/Index/Hero.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { Loader2, UserPen } from 'lucide-svelte';
+	import { Loader2, UserPen, ChevronRight } from 'lucide-svelte';
 	import { signIn } from '@auth/sveltekit/client';
 	import { page } from '$app/stores';
 	import { onMount } from 'svelte';
 	import { getReleaseVersion } from '$lib/utils/getReleaseVersion';
-	import { IconBrandGithub } from '@tabler/icons-svelte';
+	import { IconBrandGithub, IconBrandDiscordFilled } from '@tabler/icons-svelte';
 
 	// undefined means that we haven't received the result from getReleaseVersion
 	// null means that getReleaseVersion couldn't find the release version
@@ -34,19 +34,7 @@
 							{:else}
 								<span>{releaseVersion}</span>
 							{/if}
-							<svg
-								class="h-5 w-5 text-gray-500"
-								viewBox="0 0 20 20"
-								fill="currentColor"
-								aria-hidden="true"
-								data-slot="icon"
-							>
-								<path
-									fill-rule="evenodd"
-									d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
-									clip-rule="evenodd"
-								/>
-							</svg>
+							<ChevronRight class="h-5 w-5 text-gray-500" />
 						</span>
 					{/if}
 				</a>
@@ -63,45 +51,20 @@
 					<Button href="/profile" class="flex items-center space-x-2"
 						><UserPen /> <span>My Profile</span></Button
 					>
-					<Button
-						href="https://discord.gg/9XuRcaZR"
-						target="_blank"
-						class="flex items-center space-x-2"
-						variant="secondary"
-						><svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="24"
-							height="24"
-							viewBox="0 0 24 24"
-							fill="currentColor"
-							class="icon icon-tabler icons-tabler-filled icon-tabler-brand-discord"
-							><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path
-								d="M14.983 3l.123 .006c2.014 .214 3.527 .672 4.966 1.673a1 1 0 0 1 .371 .488c1.876 5.315 2.373 9.987 1.451 12.28c-1.003 2.005 -2.606 3.553 -4.394 3.553c-.732 0 -1.693 -.968 -2.328 -2.045a21.512 21.512 0 0 0 2.103 -.493a1 1 0 1 0 -.55 -1.924c-3.32 .95 -6.13 .95 -9.45 0a1 1 0 0 0 -.55 1.924c.717 .204 1.416 .37 2.103 .494c-.635 1.075 -1.596 2.044 -2.328 2.044c-1.788 0 -3.391 -1.548 -4.428 -3.629c-.888 -2.217 -.39 -6.89 1.485 -12.204a1 1 0 0 1 .371 -.488c1.439 -1.001 2.952 -1.459 4.966 -1.673a1 1 0 0 1 .935 .435l.063 .107l.651 1.285l.137 -.016a12.97 12.97 0 0 1 2.643 0l.134 .016l.65 -1.284a1 1 0 0 1 .754 -.54l.122 -.009zm-5.983 7a2 2 0 0 0 -1.977 1.697l-.018 .154l-.005 .149l.005 .15a2 2 0 1 0 1.995 -2.15zm6 0a2 2 0 0 0 -1.977 1.697l-.018 .154l-.005 .149l.005 .15a2 2 0 1 0 1.995 -2.15z"
-							/></svg
-						> <span>Join the Community</span></Button
-					>
 				{:else}
 					<Button on:click={() => signIn('github')} class="flex items-center space-x-2"
 						><IconBrandGithub /> <span>Sign in with Github</span></Button
 					>
-					<Button
-						href="https://discord.gg/9XuRcaZR"
-						target="_blank"
-						class="flex items-center space-x-2"
-						variant="secondary"
-						><svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="24"
-							height="24"
-							viewBox="0 0 24 24"
-							fill="currentColor"
-							class="icon icon-tabler icons-tabler-filled icon-tabler-brand-discord"
-							><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path
-								d="M14.983 3l.123 .006c2.014 .214 3.527 .672 4.966 1.673a1 1 0 0 1 .371 .488c1.876 5.315 2.373 9.987 1.451 12.28c-1.003 2.005 -2.606 3.553 -4.394 3.553c-.732 0 -1.693 -.968 -2.328 -2.045a21.512 21.512 0 0 0 2.103 -.493a1 1 0 1 0 -.55 -1.924c-3.32 .95 -6.13 .95 -9.45 0a1 1 0 0 0 -.55 1.924c.717 .204 1.416 .37 2.103 .494c-.635 1.075 -1.596 2.044 -2.328 2.044c-1.788 0 -3.391 -1.548 -4.428 -3.629c-.888 -2.217 -.39 -6.89 1.485 -12.204a1 1 0 0 1 .371 -.488c1.439 -1.001 2.952 -1.459 4.966 -1.673a1 1 0 0 1 .935 .435l.063 .107l.651 1.285l.137 -.016a12.97 12.97 0 0 1 2.643 0l.134 .016l.65 -1.284a1 1 0 0 1 .754 -.54l.122 -.009zm-5.983 7a2 2 0 0 0 -1.977 1.697l-.018 .154l-.005 .149l.005 .15a2 2 0 1 0 1.995 -2.15zm6 0a2 2 0 0 0 -1.977 1.697l-.018 .154l-.005 .149l.005 .15a2 2 0 1 0 1.995 -2.15z"
-							/></svg
-						> <span>Join the Community</span></Button
-					>
 				{/if}
+				<Button
+					href="https://discord.gg/9XuRcaZR"
+					target="_blank"
+					class="flex items-center space-x-2"
+					variant="secondary"
+				>
+					<IconBrandDiscordFilled />
+					<span>Join the Community</span>
+				</Button>
 			</div>
 		</div>
 		<div

--- a/src/lib/components/MyProfile/ImportFromGithub.svelte
+++ b/src/lib/components/MyProfile/ImportFromGithub.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import { IconBrandGithub } from '@tabler/icons-svelte';
-	import type { PageData } from '../../../routes/profile/$types';
 	import type { Repository } from '$lib/types/GithubData';
 	import ImportFromGithubModal from '$lib/components/MyProfile/ImportFromGithubModal.svelte';
 
-	export let data: PageData;
+	export let username: string;
+	export let linksLength: number;
 
-	$: isLimitReached = data.links.length >= 15;
+	$: isLimitReached = linksLength >= 15;
 	let isModalVisible = false;
 	let repos: Repository[] = [];
 
@@ -26,20 +26,17 @@
 	};
 </script>
 
-<div class="flex w-full space-x-4">
-	<div class="space-y-2">
-		<span class="invisible block">a</span>
-		<Button
-			disabled={isLimitReached}
-			class="flex space-x-2"
-			on:click={() => fetchGithubRepos(data.userData.username)}
-		>
-			<IconBrandGithub />
-			<span>Import from GitHub</span>
-		</Button>
-	</div>
+<div class="flex space-x-4">
+	<Button
+		disabled={isLimitReached}
+		class="flex space-x-2"
+		on:click={() => fetchGithubRepos(username)}
+	>
+		<IconBrandGithub />
+		<span>Import from GitHub</span>
+	</Button>
 </div>
 
 {#if isModalVisible}
-	<ImportFromGithubModal {repos} {isModalVisible} {closeModal} linksLength={data.links.length} />
+	<ImportFromGithubModal {repos} {isModalVisible} {closeModal} {linksLength} />
 {/if}

--- a/src/lib/components/MyProfile/ImportFromGithubModal.svelte
+++ b/src/lib/components/MyProfile/ImportFromGithubModal.svelte
@@ -4,7 +4,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Table from '$lib/components/ui/table';
 	import { Checkbox } from '$lib/components/ui/checkbox';
-	import { Star } from 'lucide-svelte';
+	import { Star, X } from 'lucide-svelte';
 	import { IconBrandGithub, IconChecks } from '@tabler/icons-svelte';
 
 	export let repos: Repository[] = [];
@@ -87,9 +87,13 @@
 			>
 				<Card.Root>
 					<Card.Header>
-						<Card.Title class="flex flex-row items-center gap-2">
+						<Card.Title class="flex items-center justify-between gap-2">
 							<IconBrandGithub />
 							<span>Import From Github</span>
+							<div class="flex-grow"></div>
+							<Button variant="ghost" on:click={closeModal}>
+								<X />
+							</Button>
 						</Card.Title>
 					</Card.Header>
 					<Card.Content>

--- a/src/lib/components/MyProfile/ImportFromGithubModal.svelte
+++ b/src/lib/components/MyProfile/ImportFromGithubModal.svelte
@@ -75,7 +75,7 @@
 </script>
 
 {#if isModalVisible}
-	<div class="relative z-10" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+	<div class="relative z-50" aria-labelledby="modal-title" role="dialog" aria-modal="true">
 		<div
 			class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
 			aria-hidden="true"

--- a/src/lib/components/MyProfile/LinkForm.svelte
+++ b/src/lib/components/MyProfile/LinkForm.svelte
@@ -5,8 +5,10 @@
 	import { type SuperValidated, type Infer, superForm } from 'sveltekit-superforms';
 	import { zodClient } from 'sveltekit-superforms/adapters';
 	import type { Link } from '@prisma/client';
+	import ImportFromGithub from '$lib/components/MyProfile/ImportFromGithub.svelte';
 
 	export let data: SuperValidated<Infer<LinksSchema>>;
+	export let username: string;
 	export let linksLength: number;
 	export let links: Link[] = [];
 	let isLimitReached = false;
@@ -21,13 +23,8 @@
 	$: $formData.order = linksLength;
 </script>
 
-<form
-	method="POST"
-	use:enhance
-	action="?/createLink"
-	class="flex w-full max-w-lg items-start justify-start space-x-4"
->
-	<div class="flex flex-col">
+<form method="POST" use:enhance action="?/createLink" class="w-full max-w-lg space-y-4">
+	<div class="flex space-x-4">
 		<Form.Field {form} name="title">
 			<Form.Control let:attrs>
 				<Form.Label>Title</Form.Label>
@@ -35,9 +32,7 @@
 			</Form.Control>
 			<Form.FieldErrors />
 		</Form.Field>
-	</div>
 
-	<div class="flex flex-col">
 		<Form.Field {form} name="url">
 			<Form.Control let:attrs>
 				<Form.Label>URL</Form.Label>
@@ -47,16 +42,16 @@
 		</Form.Field>
 	</div>
 
-	<div class="space-y-2">
-		<span class="invisible block">a</span>
-		<Form.Button disabled={isLimitReached} class="mt-5 flex align-bottom">Add</Form.Button>
-	</div>
-
 	<Form.Field {form} name="order">
 		<Form.Control let:attrs>
 			<Input {...attrs} bind:value={$formData.order} type="hidden" />
 		</Form.Control>
 	</Form.Field>
+
+	<div class="flex space-x-4">
+		<Form.Button disabled={isLimitReached}>Add</Form.Button>
+		<ImportFromGithub {linksLength} {username} />
+	</div>
 </form>
 
 {#if isLimitReached}

--- a/src/lib/components/MyProfile/SideNav.svelte
+++ b/src/lib/components/MyProfile/SideNav.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { sideNavOpt } from '$lib/constants/sideNavOptions';
 	import Search from '$lib/components/MyProfile/Search.svelte';
+	import { Menu, X } from 'lucide-svelte';
+	import { Button } from '$lib/components/ui/button';
 
 	let isSidebarOpen = false;
 
@@ -24,37 +26,19 @@
 			<!-- Sidebar Panel -->
 			<div class="fixed inset-0 flex">
 				<div
-					class="relative mr-16 flex w-full max-w-xs flex-1 transform transition duration-300 ease-in-out"
+					class="relative flex w-full flex-1 transform transition duration-300 ease-in-out"
 					class:translate-x-full={!isSidebarOpen}
 				>
-					<!-- Close Button -->
-					<div class="absolute left-full top-0 flex w-16 justify-center pt-5">
-						<button on:click={toggleSidebar} type="button" class="-m-2.5 p-2.5">
-							<span class="sr-only">Close sidebar</span>
-							<svg
-								class="h-6 w-6 text-white"
-								fill="none"
-								viewBox="0 0 24 24"
-								stroke-width="1.5"
-								stroke="currentColor"
-								aria-hidden="true"
-							>
-								<path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
-							</svg>
-						</button>
-					</div>
-
 					<!-- Sidebar Content for Mobile -->
 					<div class="flex grow flex-col gap-y-5 overflow-y-auto px-6 pb-4">
-						<div class="flex h-16 shrink-0 items-center">
-							<!-- Logo 
-				<img
-					class="h-8 w-auto"
-					src="https://tailwindui.com/plus/img/logos/mark.svg?color=indigo&shade=600"
-					alt="Your Company"
-				/>
-                -->
+						<div class="flex h-16 shrink-0 items-center justify-between">
 							<h1 class="text-2xl font-bold">Route</h1>
+
+							<!-- Close Button -->
+							<Button on:click={toggleSidebar} type="button" variant="ghost">
+								<span class="sr-only">Close sidebar</span>
+								<X class="h-6 w-6" />
+							</Button>
 						</div>
 						<nav class="flex flex-1 flex-col">
 							<ul role="list" class="flex flex-1 flex-col gap-y-7">
@@ -62,7 +46,7 @@
 									<li>
 										<a
 											href={option.path}
-											class="group flex gap-x-3 rounded-lg p-3 text-sm font-semibold hover:border hover:bg-transparent"
+											class="group flex items-center gap-x-3 rounded-lg p-3 text-sm font-semibold hover:border hover:bg-transparent"
 										>
 											<svelte:component this={option.icon} class="h-6 w-6" />
 											{option.name}
@@ -81,13 +65,6 @@
 	<div class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
 		<div class="flex grow flex-col gap-y-5 overflow-y-auto border-r px-6 pb-4">
 			<div class="flex h-16 shrink-0 items-center">
-				<!-- Logo 
-				<img
-					class="h-8 w-auto"
-					src="https://tailwindui.com/plus/img/logos/mark.svg?color=indigo&shade=600"
-					alt="Your Company"
-				/>
-                -->
 				<h1 class="text-2xl font-bold">Route</h1>
 			</div>
 			<nav class="flex flex-1 flex-col">
@@ -121,20 +98,7 @@
 			<!-- Mobile Open Sidebar Button -->
 			<button on:click={toggleSidebar} type="button" class="-m-2.5 p-2.5 lg:hidden">
 				<span class="sr-only">Open sidebar</span>
-				<svg
-					class="h-6 w-6"
-					fill="none"
-					viewBox="0 0 24 24"
-					stroke-width="1.5"
-					stroke="currentColor"
-					aria-hidden="true"
-				>
-					<path
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
-					/>
-				</svg>
+				<Menu />
 			</button>
 
 			<!-- Search Form -->

--- a/src/lib/components/MyProfile/SideNav.svelte
+++ b/src/lib/components/MyProfile/SideNav.svelte
@@ -116,7 +116,7 @@
 	<!-- Main Content Area -->
 	<div class="lg:pl-72">
 		<div
-			class="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8"
+			class="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b bg-background px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8"
 		>
 			<!-- Mobile Open Sidebar Button -->
 			<button on:click={toggleSidebar} type="button" class="-m-2.5 p-2.5 lg:hidden">

--- a/src/lib/components/MyProfile/SocialsForm.svelte
+++ b/src/lib/components/MyProfile/SocialsForm.svelte
@@ -7,6 +7,7 @@
 
 	import * as Select from '$lib/components/ui/select';
 	import { socials, SocialsInputType } from '$lib/constants/socials';
+	import { findSocialIcon } from '$lib/utils/findSocialIcon';
 
 	export let data: SuperValidated<Infer<SocialsSchema>>;
 
@@ -51,7 +52,7 @@
 						{#each socials as social}
 							<Select.Item value={social.name}>
 								<div class="flex flex-row items-center justify-center gap-4">
-									<svelte:component this={social.icon} />
+									<svelte:component this={findSocialIcon(social.name)} />
 									<span>{social.name}</span>
 								</div>
 							</Select.Item>
@@ -62,7 +63,7 @@
 			</Form.Control>
 			<Form.FieldErrors />
 		</Form.Field>
-		<Form.Field {form} name="socialURL" >
+		<Form.Field {form} name="socialURL">
 			<Form.Control let:attrs>
 				<Form.Label>{selectedSocialInputType}</Form.Label>
 				<Input {...attrs} bind:value={$formData.socialURL} />

--- a/src/lib/components/MyProfile/Timeline.svelte
+++ b/src/lib/components/MyProfile/Timeline.svelte
@@ -44,7 +44,7 @@
 							<span
 								class={`flex h-8 w-8 items-center justify-center rounded-full ${getActivityColor(activity.activityType)}`}
 							>
-								<svelte:component this={findSocialIcon(activity.activityType)} class="h-5 w-5 " />
+								<svelte:component this={findSocialIcon(activity.activityType)} class="h-5 w-5" />
 							</span>
 						</div>
 						<div class="flex min-w-0 flex-1 justify-between space-x-4 pt-1.5">

--- a/src/lib/constants/socials.ts
+++ b/src/lib/constants/socials.ts
@@ -1,12 +1,4 @@
-import {
-	IconBrandDiscordFilled,
-	IconBrandLinkedin,
-	IconBrandTelegram,
-	IconBrandGitlab,
-	IconBrandSpotifyFilled
-} from '@tabler/icons-svelte';
-
-//Social media
+// Social media
 // Import to add differences in how they're handled in the frontend
 
 // To be adjusted if we ever need more input types for socials
@@ -19,35 +11,30 @@ export enum SocialsInputType {
 export const socials = [
 	{
 		name: 'Discord',
-		icon: IconBrandDiscordFilled,
 		redirect: false,
 		inputType: SocialsInputType.USERNAME,
 		domains: ['discord.com']
 	},
 	{
 		name: 'LinkedIn',
-		icon: IconBrandLinkedin,
 		redirect: true,
 		inputType: SocialsInputType.URL,
 		domains: ['linkedin.com']
 	},
 	{
 		name: 'Telegram',
-		icon: IconBrandTelegram,
 		redirect: false,
 		inputType: SocialsInputType.USERNAME,
 		domains: ['t.me']
 	},
 	{
 		name: 'Spotify',
-		icon: IconBrandSpotifyFilled,
 		redirect: true,
 		inputType: SocialsInputType.URL,
 		domains: ['spotify.com']
 	},
 	{
 		name: 'Gitlab',
-		icon: IconBrandGitlab,
 		redirect: true,
 		inputType: SocialsInputType.URL,
 		domains: ['gitlab.com']

--- a/src/lib/schemas/links.ts
+++ b/src/lib/schemas/links.ts
@@ -4,8 +4,9 @@ export const linksSchema = z.object({
 	title: z.string().min(1).max(50),
 	url: z
 		.string()
-		.min(10)
+		.min(1)
 		.max(200)
+		.url()
 		.refine((val) => val.startsWith('http://') || val.startsWith('https://'), {
 			message: 'Oops! URLs usually start with http:// or https:// :P'
 		}),

--- a/src/lib/utils/findSocialIcon.ts
+++ b/src/lib/utils/findSocialIcon.ts
@@ -6,23 +6,32 @@ import {
 	IconSocial,
 	IconBrandSpotifyFilled,
 	IconLink,
-	IconChess
+	IconChess,
+	IconBrandDiscordFilled,
+	IconBrandGitlab,
+	IconBrandLinkedin,
+	IconBrandTelegram
 } from '@tabler/icons-svelte';
+
+const icons: Record<string, typeof IconPlus> = {
+	LINK_CREATED: IconLink,
+	LINK_DELETED: IconLink,
+	HOBBY_CREATED: IconRollerSkating,
+	HOBBY_DELETED: IconRollerSkating,
+	SOCIAL_CREATED: IconSocial,
+	SOCIAL_DELETED: IconSocial,
+	UNLINK_SPOTIFY: IconBrandSpotifyFilled,
+	LINK_SPOTIFY: IconBrandSpotifyFilled,
+	CHESS_COM_CREATED: IconChess,
+	CHESS_COM_DELETED: IconChess,
+	Discord: IconBrandDiscordFilled,
+	LinkedIn: IconBrandLinkedin,
+	Telegram: IconBrandTelegram,
+	Gitlab: IconBrandGitlab,
+	Spotify: IconBrandSpotifyFilled
+};
 
 // Mapping function for both social names and activity types
 export const findSocialIcon = (activityType: string) => {
-	const icons: Record<string, typeof IconPlus> = {
-		LINK_CREATED: IconLink,
-		LINK_DELETED: IconLink,
-		HOBBY_CREATED: IconRollerSkating,
-		HOBBY_DELETED: IconRollerSkating,
-		SOCIAL_CREATED: IconSocial,
-		SOCIAL_DELETED: IconSocial,
-		UNLINK_SPOTIFY: IconBrandSpotifyFilled,
-		LINK_SPOTIFY: IconBrandSpotifyFilled,
-		CHESS_COM_CREATED: IconChess,
-		CHESS_COM_DELETED: IconChess
-	};
-
 	return icons[activityType] || IconPlus;
 };

--- a/src/routes/profile/integrations/+page.svelte
+++ b/src/routes/profile/integrations/+page.svelte
@@ -100,7 +100,7 @@
 					description="You can link your Chess.com account here to showcase your stats."
 					title="Chess.com"
 				>
-					<div class="flex flex-row items-stretch gap-4">
+					<div class="flex flex-row items-stretch gap-4 pb-6">
 						<ChessComForm data={data.chessComForm} />
 					</div>
 				</FormCardHeader>

--- a/src/routes/profile/integrations/+page.svelte
+++ b/src/routes/profile/integrations/+page.svelte
@@ -4,7 +4,6 @@
 	import FormCardHeader from '$lib/components/MyProfile/FormCardHeader.svelte';
 	import LinkForm from '$lib/components/MyProfile/LinkForm.svelte';
 	import UserLinks from '$lib/components/MyProfile/UserLinks.svelte';
-	import ImportFromGithub from '$lib/components/MyProfile/ImportFromGithub.svelte';
 	import type { PageData } from '../$types';
 	import { AudioLines } from 'lucide-svelte';
 	import { enhance } from '$app/forms';
@@ -30,8 +29,12 @@
 				title="Links"
 			>
 				<div class="flex flex-row items-stretch gap-4">
-					<LinkForm data={data.form} linksLength={data.links.length} links={data.links} />
-					<ImportFromGithub {data} />
+					<LinkForm
+						username={data.userData.username}
+						data={data.form}
+						linksLength={data.links.length}
+						links={data.links}
+					/>
 				</div>
 			</FormCardHeader>
 			<Card.Content>


### PR DESCRIPTION
This PR is a compilation of small fixes:
- Replaced `<svg>` elements with tabler icons/lucide svelte
- Made `LinkForm` span vertically
- Added a second close button at the top of the `ImportFromGithubModal`
- Fixed `findSocialIcon` for brand icons
- Added zod's `.url()` for the `LinkForm` schema
- Added a background to the search area
- Fixed some alignment issues